### PR TITLE
Add an option to crafting tasks to count previously crafted items into account

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+* text eol=lf
+
+*.[jJ][aA][rR]          binary
+
+*.[pP][nN][gG]          binary
+*.[jJ][pP][gG]          binary
+*.[jJ][pP][eE][gG]      binary
+*.[gG][iI][fF]          binary
+*.[tT][iI][fF]          binary
+*.[tT][iI][fF][fF]      binary
+*.[iI][cC][oO]          binary
+*.[sS][vV][gG]          text
+*.[eE][pP][sS]          binary
+*.[xX][cC][fF]          binary
+
+*.[kK][aA][rR]          binary
+*.[mM]4[aA]             binary
+*.[mM][iI][dD]          binary
+*.[mM][iI][dD][iI]      binary
+*.[mM][pP]3             binary
+*.[oO][gG][gG]          binary
+*.[rR][aA]              binary
+
+*.7[zZ]                 binary
+*.[gG][zZ]              binary
+*.[tT][aA][rR]          binary
+*.[tT][gG][zZ]          binary
+*.[zZ][iI][pP]          binary
+
+*.[tT][cC][nN]          binary
+*.[sS][oO]              binary
+*.[dD][lL][lL]          binary
+*.[dD][yY][lL][iI][bB]  binary
+*.[pP][sS][dD]          binary
+
+*.[pP][aA][tT][cC][hH]  -text
+
+*.[bB][aA][tT]          text eol=crlf
+*.[cC][mM][dD]          text eol=crlf
+*.[pP][sS]1             text eol=crlf
+
+*[aA][uU][tT][oO][gG][eE][nN][eE][rR][aA][tT][eE][dD]* binary

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,39 @@
-//version: 1650343995
+//version: 1662920829
 /*
-DO NOT CHANGE THIS FILE!
-
-Also, you may replace this file at any time if there is an update available.
-Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle for updates.
-*/
+ DO NOT CHANGE THIS FILE!
+ Also, you may replace this file at any time if there is an update available.
+ Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle for updates.
+ */
 
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.matthewprenger.cursegradle.CurseArtifact
+import com.matthewprenger.cursegradle.CurseRelation
+import com.modrinth.minotaur.dependencies.ModDependency
+import com.modrinth.minotaur.dependencies.VersionDependency
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 
 buildscript {
     repositories {
+        mavenCentral()
+
         maven {
             name 'forge'
             url 'https://maven.minecraftforge.net'
+        }
+        maven {
+            // GTNH ForgeGradle Fork
+            name = "GTNH Maven"
+            url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
         maven {
             name 'sonatype'
@@ -28,30 +43,39 @@ buildscript {
             name 'Scala CI dependencies'
             url 'https://repo1.maven.org/maven2/'
         }
-        maven {
-            name 'jitpack'
-            url 'https://jitpack.io'
-        }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.9'
     }
 }
-
 plugins {
     id 'java-library'
     id 'idea'
     id 'eclipse'
     id 'scala'
     id 'maven-publish'
-    id 'org.jetbrains.kotlin.jvm'        version '1.5.30' apply false
-    id 'org.jetbrains.kotlin.kapt'       version '1.5.30' apply false
-    id 'org.ajoberstar.grgit'            version '4.1.1'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.30' apply false
+    id 'org.jetbrains.kotlin.kapt' version '1.5.30' apply false
+    id 'com.google.devtools.ksp' version '1.5.30-1.0.0' apply false
+    id 'org.ajoberstar.grgit' version '4.1.1'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
-    id 'com.palantir.git-version'        version '0.13.0' apply false
-    id 'de.undercouch.download'          version '5.0.1'
-    id 'com.github.gmazzo.buildconfig'   version '3.0.3'  apply false
+    id 'com.palantir.git-version' version '0.13.0' apply false
+    id 'de.undercouch.download' version '5.0.1'
+    id 'com.github.gmazzo.buildconfig' version '3.0.3' apply false
+    id 'com.diffplug.spotless' version '6.7.2' apply false
+    id 'com.modrinth.minotaur' version '2.+' apply false
+    id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
 }
+boolean settingsupdated = verifySettingsGradle()
+settingsupdated = verifyGitAttributes() || settingsupdated
+if (settingsupdated)
+    throw new GradleException("Settings has been updated, please re-run task.")
+
+dependencies {
+    implementation 'com.diffplug:blowdryer:1.6.0'
+}
+
+apply plugin: 'com.diffplug.blowdryer'
 
 if (project.file('.git/HEAD').isFile()) {
     apply plugin: 'com.palantir.git-version'
@@ -77,7 +101,14 @@ idea {
     }
 }
 
-if(JavaVersion.current() != JavaVersion.VERSION_1_8) {
+boolean disableSpotless = project.hasProperty("disableSpotless") ? project.disableSpotless.toBoolean() : false
+
+if (!disableSpotless) {
+    apply plugin: 'com.diffplug.spotless'
+    apply from: Blowdryer.file('spotless.gradle')
+}
+
+if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
     throw new GradleException("This project requires Java 8, but it's running on " + JavaVersion.current())
 }
 
@@ -102,8 +133,15 @@ checkPropertyExists("containsMixinsAndOrCoreModOnly")
 checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
-boolean noPublishedSources = project.findProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
-boolean usesMixinDebug = project.findProperty('usesMixinDebug') ?: project.usesMixins.toBoolean()
+propertyDefaultIfUnset("noPublishedSources", false)
+propertyDefaultIfUnset("usesMixinDebug", project.usesMixins)
+propertyDefaultIfUnset("forceEnableMixins", false)
+propertyDefaultIfUnset("channel", "stable")
+propertyDefaultIfUnset("mappingsVersion", "12")
+propertyDefaultIfUnset("modrinthProjectId", "")
+propertyDefaultIfUnset("modrinthRelations", "")
+propertyDefaultIfUnset("curseForgeProjectId", "")
+propertyDefaultIfUnset("curseForgeRelations", "")
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
@@ -112,53 +150,53 @@ String kotlinSourceDir = "src/main/kotlin/"
 String targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/")
 String targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/")
 String targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/")
-if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
     throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
 }
 
-if(apiPackage) {
+if (apiPackage) {
     targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
     targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
     targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
-    if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+    if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
         throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
 }
 
-if(accessTransformersFile) {
+if (accessTransformersFile) {
     String targetFile = "src/main/resources/META-INF/" + accessTransformersFile
-    if(!getFile(targetFile).exists()) {
+    if (!getFile(targetFile).exists()) {
         throw new GradleException("Could not resolve \"accessTransformersFile\"! Could not find " + targetFile)
     }
 }
 
-if(usesMixins.toBoolean()) {
-    if(mixinsPackage.isEmpty() || mixinPlugin.isEmpty()) {
+if (usesMixins.toBoolean()) {
+    if (mixinsPackage.isEmpty() || mixinPlugin.isEmpty()) {
         throw new GradleException("\"mixinPlugin\" requires \"mixinsPackage\" and \"mixinPlugin\" to be set!")
     }
 
     targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
     targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
     targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
-    if(!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
-        throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala  + " or " + targetPackageKotlin)
+    if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
+        throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
 
     String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
     String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".scala"
     String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
     String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".kt"
-    if(!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+    if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
         throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
     }
 }
 
-if(coreModClass) {
+if (coreModClass) {
     String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
     String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".scala"
     String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
     String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".kt"
-    if(!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+    if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
         throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
     }
 }
@@ -188,7 +226,7 @@ try {
 catch (Exception ignored) {
     out.style(Style.Failure).text(
         'This mod must be version controlled by Git AND the repository must provide at least one tag,\n' +
-        'or the VERSION override must be set! ').style(Style.SuccessHeader).text('(Do NOT download from GitHub using the ZIP option, instead\n' +
+            'or the VERSION override must be set! ').style(Style.SuccessHeader).text('(Do NOT download from GitHub using the ZIP option, instead\n' +
         'clone the repository, see ').style(Style.Info).text('https://gtnh.miraheze.org/wiki/Development').style(Style.SuccessHeader).println(' for details.)'
     )
     versionOverride = 'NO-GIT-TAG-SET'
@@ -199,22 +237,21 @@ ext {
     modVersion = identifiedVersion
 }
 
-if(identifiedVersion == versionOverride) {
+if (identifiedVersion == versionOverride) {
     out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
 }
 
 group = modGroup
-if(project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
+if (project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
     archivesBaseName = customArchiveBaseName
-}
-else {
+} else {
     archivesBaseName = modId
 }
 
 def arguments = []
 def jvmArguments = []
 
-if (usesMixins.toBoolean()) {
+if (usesMixins.toBoolean() || forceEnableMixins) {
     arguments += [
         "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
     ]
@@ -233,16 +270,16 @@ minecraft {
 
     if (replaceGradleTokenInFile) {
         replaceIn replaceGradleTokenInFile
-        if(gradleTokenModId) {
+        if (gradleTokenModId) {
             replace gradleTokenModId, modId
         }
-        if(gradleTokenModName) {
+        if (gradleTokenModName) {
             replace gradleTokenModName, modName
         }
-        if(gradleTokenVersion) {
+        if (gradleTokenVersion) {
             replace gradleTokenVersion, modVersion
         }
-        if(gradleTokenGroupName) {
+        if (gradleTokenGroupName) {
             replace gradleTokenGroupName, modGroup
         }
     }
@@ -251,7 +288,7 @@ minecraft {
         args(arguments)
         jvmArgs(jvmArguments)
 
-        if(developmentEnvironmentUserName) {
+        if (developmentEnvironmentUserName) {
             args("--username", developmentEnvironmentUserName)
         }
     }
@@ -262,7 +299,7 @@ minecraft {
     }
 }
 
-if(file('addon.gradle').exists()) {
+if (file('addon.gradle').exists()) {
     apply from: 'addon.gradle'
 }
 
@@ -279,7 +316,7 @@ repositories {
         name 'Overmind forge repo mirror'
         url 'https://gregtech.overminddl1.com/'
     }
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean() || forceEnableMixins) {
         maven {
             name 'sponge'
             url 'https://repo.spongepowered.org/repository/maven-public'
@@ -291,11 +328,13 @@ repositories {
 }
 
 dependencies {
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
         annotationProcessor('org.spongepowered:mixin:0.8-SNAPSHOT')
+    }
+    if (usesMixins.toBoolean() || forceEnableMixins) {
         // using 0.8 to workaround a issue in 0.7 which fails mixin application
         compile('com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH') {
             // Mixin includes a lot of dependencies that are too up-to-date
@@ -353,7 +392,10 @@ shadowJar {
     }
 
     minimize()  // This will only allow shading for actually used classes
-    configurations = [project.configurations.shadowImplementation, project.configurations.shadowCompile]
+    configurations = [
+        project.configurations.shadowImplementation,
+        project.configurations.shadowCompile
+    ]
     dependsOn(relocateShadowJar)
 }
 
@@ -368,38 +410,38 @@ jar {
         attributes(getManifestAttributes())
     }
 
-    if(usesShadowedDependencies.toBoolean()) {
+    if (usesShadowedDependencies.toBoolean()) {
         dependsOn(shadowJar)
         enabled = false
     }
 }
 
 reobf {
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         addExtraSrgFile mixinSrg
     }
 }
 
 afterEvaluate {
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         tasks.compileJava {
             options.compilerArgs += [
-                    "-AreobfSrgFile=${tasks.reobf.srg}",
-                    "-AoutSrgFile=${mixinSrg}",
-                    "-AoutRefMapFile=${refMap}",
-                    // Elan: from what I understand they are just some linter configs so you get some warning on how to properly code
-                    "-XDenableSunApiLintControl",
-                    "-XDignore.symbol.file"
+                "-AreobfSrgFile=${tasks.reobf.srg}",
+                "-AoutSrgFile=${mixinSrg}",
+                "-AoutRefMapFile=${refMap}",
+                // Elan: from what I understand they are just some linter configs so you get some warning on how to properly code
+                "-XDenableSunApiLintControl",
+                "-XDignore.symbol.file"
             ]
         }
     }
 }
 
 runClient {
-    if(developmentEnvironmentUserName) {
+    if (developmentEnvironmentUserName) {
         arguments += [
-                "--username",
-                developmentEnvironmentUserName
+            "--username",
+            developmentEnvironmentUserName
         ]
     }
 
@@ -414,9 +456,9 @@ runServer {
 
 tasks.withType(JavaExec).configureEach {
     javaLauncher.set(
-            javaToolchains.launcherFor {
-                languageVersion = projectJavaVersion
-            }
+        javaToolchains.launcherFor {
+            languageVersion = projectJavaVersion
+        }
     )
 }
 
@@ -424,6 +466,7 @@ processResources {
     // this will ensure that this task is redone when the versions change.
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
+    exclude("spotless.gradle")
 
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
@@ -436,43 +479,44 @@ processResources {
             "modName": modName
     }
 
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         from refMap
     }
 
     // copy everything else that's not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
+        exclude 'spotless.gradle'
     }
 }
 
 def getManifestAttributes() {
     def manifestAttributes = [:]
-    if(!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
+    if (!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
         manifestAttributes += ["FMLCorePluginContainsFMLMod": true]
     }
 
-    if(accessTransformersFile) {
-        manifestAttributes += ["FMLAT" : accessTransformersFile.toString()]
+    if (accessTransformersFile) {
+        manifestAttributes += ["FMLAT": accessTransformersFile.toString()]
     }
 
-    if(coreModClass) {
+    if (coreModClass) {
         manifestAttributes += ["FMLCorePlugin": modGroup + "." + coreModClass]
     }
 
-    if(usesMixins.toBoolean()) {
+    if (usesMixins.toBoolean()) {
         manifestAttributes += [
-                "TweakClass" : "org.spongepowered.asm.launch.MixinTweaker",
-                "MixinConfigs" : "mixins." + modId + ".json",
-                "ForceLoadAsMod" : !containsMixinsAndOrCoreModOnly.toBoolean()
+            "TweakClass"    : "org.spongepowered.asm.launch.MixinTweaker",
+            "MixinConfigs"  : "mixins." + modId + ".json",
+            "ForceLoadAsMod": !containsMixinsAndOrCoreModOnly.toBoolean()
         ]
     }
     return manifestAttributes
 }
 
 task sourcesJar(type: Jar) {
-    from (sourceSets.main.allSource)
-    from (file("$projectDir/LICENSE"))
+    from(sourceSets.main.allSource)
+    from(file("$projectDir/LICENSE"))
     getArchiveClassifier().set('sources')
 }
 
@@ -491,7 +535,10 @@ task shadowDevJar(type: ShadowJar) {
     }
 
     minimize()  // This will only allow shading for actually used classes
-    configurations = [project.configurations.shadowImplementation, project.configurations.shadowCompile]
+    configurations = [
+        project.configurations.shadowImplementation,
+        project.configurations.shadowCompile
+    ]
 }
 
 task relocateShadowDevJar(type: ConfigureShadowRelocation) {
@@ -519,22 +566,22 @@ task devJar(type: Jar) {
         attributes(getManifestAttributes())
     }
 
-    if(usesShadowedDependencies.toBoolean()) {
+    if (usesShadowedDependencies.toBoolean()) {
         dependsOn(circularResolverJar)
         enabled = false
     }
 }
 
 task apiJar(type: Jar) {
-    from (sourceSets.main.allSource) {
+    from(sourceSets.main.allSource) {
         include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
-    from (sourceSets.main.output) {
+    from(sourceSets.main.output) {
         include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
-    from (sourceSets.main.resources.srcDirs) {
+    from(sourceSets.main.resources.srcDirs) {
         include("LICENSE")
     }
 
@@ -542,11 +589,11 @@ task apiJar(type: Jar) {
 }
 
 artifacts {
-    if(!noPublishedSources) {
+    if (!noPublishedSources) {
         archives sourcesJar
     }
     archives devJar
-    if(apiPackage) {
+    if (apiPackage) {
         archives apiJar
     }
 }
@@ -564,10 +611,10 @@ publishing {
     publications {
         maven(MavenPublication) {
             from components.java
-            if(usesShadowedDependencies.toBoolean()) {
+            if (usesShadowedDependencies.toBoolean()) {
                 artifact source: shadowJar, classifier: ""
             }
-            if(!noPublishedSources) {
+            if (!noPublishedSources) {
                 artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
@@ -582,8 +629,11 @@ publishing {
 
             // remove extra garbage from minecraft and minecraftDeps configuration
             pom.withXml {
-                def badArtifacts = [:].withDefault {[] as Set<String>}
-                for (configuration in [projectConfigs.minecraft, projectConfigs.minecraftDeps]) {
+                def badArtifacts = [:].withDefault { [] as Set<String> }
+                for (configuration in [
+                    projectConfigs.minecraft,
+                    projectConfigs.minecraftDeps
+                ]) {
                     for (dependency in configuration.allDependencies) {
                         badArtifacts[dependency.group == null ? "" : dependency.group] += dependency.name
                     }
@@ -612,6 +662,107 @@ publishing {
     }
 }
 
+if (modrinthProjectId.size() != 0) {
+    apply plugin: 'com.modrinth.minotaur'
+
+    File changelogFile = new File("CHANGELOG.md")
+
+    modrinth {
+        token = System.getenv("MODRINTH_TOKEN")
+        projectId = modrinthProjectId
+        versionNumber = identifiedVersion
+        versionType = identifiedVersion.endsWith("-pre") ? "beta" : "release"
+        changelog = changelogFile.exists() ? changelogFile.getText("UTF-8") : ""
+        uploadFile = jar
+        additionalFiles = getSecondaryArtifacts()
+        gameVersions = [minecraftVersion]
+        loaders = ["forge"]
+        debugMode = false
+    }
+
+    if (modrinthRelations.size() != 0) {
+        String[] deps = modrinthRelations.split(";")
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(":")
+            String[] qual = parts[0].split("-")
+            addModrinthDep(qual[0], qual[1], parts[1])
+        }
+    }
+    tasks.modrinth.dependsOn(build)
+    tasks.publish.dependsOn(tasks.modrinth)
+}
+
+if (curseForgeProjectId.size() != 0) {
+    apply plugin: 'com.matthewprenger.cursegradle'
+
+    File changelogFile = new File("CHANGELOG.md")
+
+    curseforge {
+        apiKey = System.getenv("CURSEFORGE_TOKEN")
+        project {
+            id = curseForgeProjectId
+            if (changelogFile.exists()) {
+                changelogType = "markdown"
+                changelog = changelogFile
+            }
+            releaseType = identifiedVersion.endsWith("-pre") ? "beta" : "release"
+            addGameVersion minecraftVersion
+            addGameVersion "Forge"
+            mainArtifact jar
+            for (artifact in getSecondaryArtifacts()) addArtifact artifact
+        }
+
+        options {
+            javaIntegration = false
+            forgeGradleIntegration = false
+            debug = false
+        }
+    }
+
+    if (curseForgeRelations.size() != 0) {
+        String[] deps = curseForgeRelations.split(";")
+        deps.each { dep ->
+            if (dep.size() == 0) {
+                return
+            }
+            String[] parts = dep.split(":")
+            addCurseForgeRelation(parts[0], parts[1])
+        }
+    }
+    tasks.curseforge.dependsOn(build)
+    tasks.publish.dependsOn(tasks.curseforge)
+}
+
+def addModrinthDep(scope, type, name) {
+    com.modrinth.minotaur.dependencies.Dependency dep;
+    if (!(scope in ["required", "optional", "incompatible", "embedded"])) {
+        throw new Exception("Invalid modrinth dependency scope: " + scope)
+    }
+    switch (type) {
+        case "project":
+            dep = new ModDependency(name, scope)
+            break
+        case "version":
+            dep = new VersionDependency(name, scope)
+            break
+        default:
+            throw new Exception("Invalid modrinth dependency type: " + type)
+    }
+    project.modrinth.dependencies.add(dep)
+}
+
+def addCurseForgeRelation(type, name) {
+    if (!(type in ["requiredDependency", "embeddedLibrary", "optionalDependency", "tool", "incompatible"])) {
+        throw new Exception("Invalid CurseForge relation type: " + type)
+    }
+    CurseArtifact artifact = project.curseforge.curseProjects[0].mainArtifact
+    CurseRelation rel = (artifact.curseRelations ?: (artifact.curseRelations = new CurseRelation()))
+    rel."$type"(name)
+}
+
 // Updating
 task updateBuildScript {
     doLast {
@@ -621,7 +772,7 @@ task updateBuildScript {
     }
 }
 
-if (isNewBuildScriptVersionAvailable(projectDir.toString())) {
+if (!project.getGradle().startParameter.isOffline() && isNewBuildScriptVersionAvailable(projectDir.toString())) {
     if (autoUpdateBuildScript.toBoolean()) {
         performBuildScriptUpdate(projectDir.toString())
     } else {
@@ -630,7 +781,40 @@ if (isNewBuildScriptVersionAvailable(projectDir.toString())) {
 }
 
 static URL availableBuildScriptUrl() {
-    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/main/build.gradle")
+    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/build.gradle")
+}
+
+static URL exampleSettingsGradleUrl() {
+    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/settings.gradle.example")
+}
+
+static URL exampleGitAttributesUrl() {
+    new URL("https://raw.githubusercontent.com/GTNewHorizons/ExampleMod1.7.10/master/.gitattributes")
+}
+
+
+boolean verifyGitAttributes() {
+    def gitattributesFile = getFile(".gitattributes")
+    if (!gitattributesFile.exists()) {
+        println("Downloading default .gitattributes")
+        exampleGitAttributesUrl().withInputStream { i -> gitattributesFile.withOutputStream { it << i } }
+        exec {
+            workingDir '.'
+            commandLine 'git', 'add', '--renormalize', '.'
+        }
+        return true
+    }
+    return false
+}
+
+boolean verifySettingsGradle() {
+    def settingsFile = getFile("settings.gradle")
+    if (!settingsFile.exists()) {
+        println("Downloading default settings.gradle")
+        exampleSettingsGradleUrl().withInputStream { i -> settingsFile.withOutputStream { it << i } }
+        return true
+    }
+    return false
 }
 
 boolean performBuildScriptUpdate(String projectDir) {
@@ -638,6 +822,10 @@ boolean performBuildScriptUpdate(String projectDir) {
         def buildscriptFile = getFile("build.gradle")
         availableBuildScriptUrl().withInputStream { i -> buildscriptFile.withOutputStream { it << i } }
         out.style(Style.Success).print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
+        boolean settingsupdated = verifySettingsGradle()
+        settingsupdated = verifyGitAttributes() || settingsupdated
+        if (settingsupdated)
+            throw new GradleException("Settings has been updated, please re-run task.")
         return true
     }
     return false
@@ -657,7 +845,7 @@ boolean isNewBuildScriptVersionAvailable(String projectDir) {
 
 static String getVersionHash(String buildScriptContent) {
     String versionLine = buildScriptContent.find("^//version: [a-z0-9]*")
-    if(versionLine != null) {
+    if (versionLine != null) {
         return versionLine.split(": ").last()
     }
     return ""
@@ -668,7 +856,103 @@ configure(updateBuildScript) {
     description = 'Updates the build script to the latest version'
 }
 
-// Deobfuscation
+// Parameter Deobfuscation
+
+task deobfParams {
+    doLast {
+
+        String mcpDir = "$project.gradle.gradleUserHomeDir/caches/minecraft/de/oceanlabs/mcp/mcp_$channel/$mappingsVersion"
+        String mcpZIP = "$mcpDir/mcp_$channel-$mappingsVersion-${minecraftVersion}.zip"
+        String paramsCSV = "$mcpDir/params.csv"
+
+        download.run {
+            src "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_$channel/$mappingsVersion-$minecraftVersion/mcp_$channel-$mappingsVersion-${minecraftVersion}.zip"
+            dest mcpZIP
+            overwrite false
+        }
+
+        if (!file(paramsCSV).exists()) {
+            println("Extracting MCP archive ...")
+            unzip(mcpZIP, mcpDir)
+        }
+
+        println("Parsing params.csv ...")
+        Map<String, String> params = new HashMap<>()
+        Files.lines(Paths.get(paramsCSV)).forEach { line ->
+            String[] cells = line.split(",")
+            if (cells.length > 2 && cells[0].matches("p_i?\\d+_\\d+_")) {
+                params.put(cells[0], cells[1])
+            }
+        }
+
+        out.style(Style.Success).println("Modified ${replaceParams(file("$projectDir/src/main/java"), params)} files!")
+        out.style(Style.Failure).println("Don't forget to verify that the code still works as before!\n It could be broken due to duplicate variables existing now\n or parameters taking priority over other variables.")
+    }
+}
+
+static int replaceParams(File file, Map<String, String> params) {
+    int fileCount = 0
+
+    if (file.isDirectory()) {
+        for (File f : file.listFiles()) {
+            fileCount += replaceParams(f, params)
+        }
+        return fileCount
+    }
+    println("Visiting ${file.getName()} ...")
+    try {
+        String content = new String(Files.readAllBytes(file.toPath()))
+        int hash = content.hashCode()
+        params.forEach { key, value ->
+            content = content.replaceAll(key, value)
+        }
+        if (hash != content.hashCode()) {
+            Files.write(file.toPath(), content.getBytes("UTF-8"))
+            return 1
+        }
+    } catch (Exception e) {
+        e.printStackTrace()
+    }
+    return 0
+}
+
+// Credit: bitsnaps (https://gist.github.com/bitsnaps/00947f2dce66f4bbdabc67d7e7b33681)
+static unzip(String zipFileName, String outputDir) {
+    byte[] buffer = new byte[16384]
+    ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFileName))
+    ZipEntry zipEntry = zis.getNextEntry()
+    while (zipEntry != null) {
+        File newFile = new File(outputDir + File.separator, zipEntry.name)
+        if (zipEntry.isDirectory()) {
+            if (!newFile.isDirectory() && !newFile.mkdirs()) {
+                throw new IOException("Failed to create directory $newFile")
+            }
+        } else {
+            // fix for Windows-created archives
+            File parent = newFile.parentFile
+            if (!parent.isDirectory() && !parent.mkdirs()) {
+                throw new IOException("Failed to create directory $parent")
+            }
+            // write file content
+            FileOutputStream fos = new FileOutputStream(newFile)
+            int len = 0
+            while ((len = zis.read(buffer)) > 0) {
+                fos.write(buffer, 0, len)
+            }
+            fos.close()
+        }
+        zipEntry = zis.getNextEntry()
+    }
+    zis.closeEntry()
+    zis.close()
+}
+
+configure(deobfParams) {
+    group = 'forgegradle'
+    description = 'Rename all obfuscated parameter names inherited from Minecraft classes'
+}
+
+// Dependency Deobfuscation
 
 def deobf(String sourceURL) {
     try {
@@ -677,42 +961,57 @@ def deobf(String sourceURL) {
 
         //get rid of directories:
         int lastSlash = fileName.lastIndexOf("/")
-        if(lastSlash > 0) {
+        if (lastSlash > 0) {
             fileName = fileName.substring(lastSlash + 1)
         }
         //get rid of extension:
-        if(fileName.endsWith(".jar")) {
+        if (fileName.endsWith(".jar") || fileName.endsWith(".litemod")) {
             fileName = fileName.substring(0, fileName.lastIndexOf("."))
         }
 
         String hostName = url.getHost()
-        if(hostName.startsWith("www.")) {
+        if (hostName.startsWith("www.")) {
             hostName = hostName.substring(4)
         }
         List parts = Arrays.asList(hostName.split("\\."))
         Collections.reverse(parts)
         hostName = String.join(".", parts)
 
-        return deobf(sourceURL, hostName + "/" + fileName)
-    } catch(Exception e) {
-        return deobf(sourceURL, "deobf/" + String.valueOf(sourceURL.hashCode()))
+        return deobf(sourceURL, "$hostName/$fileName")
+    } catch (Exception e) {
+        return deobf(sourceURL, "deobf/${sourceURL.hashCode()}")
     }
 }
 
 // The method above is to be preferred. Use this method if the filename is not at the end of the URL.
-def deobf(String sourceURL, String fileName) {
-    String cacheDir = System.getProperty("user.home") + "/.gradle/caches/"
-    String bon2Dir = cacheDir + "forge_gradle/deobf"
-    String bon2File  = bon2Dir + "/BON2-2.5.0.jar"
-    String obfFile = cacheDir + "modules-2/files-2.1/" + fileName + ".jar"
-    String deobfFile = cacheDir + "modules-2/files-2.1/" + fileName + "-deobf.jar"
+def deobf(String sourceURL, String rawFileName) {
+    String bon2Version = "2.5.1"
+    String fileName = URLDecoder.decode(rawFileName, "UTF-8")
+    String cacheDir = "$project.gradle.gradleUserHomeDir/caches"
+    String bon2Dir = "$cacheDir/forge_gradle/deobf"
+    String bon2File = "$bon2Dir/BON2-${bon2Version}.jar"
+    String obfFile = "$cacheDir/modules-2/files-2.1/${fileName}.jar"
+    String deobfFile = "$cacheDir/modules-2/files-2.1/${fileName}-deobf.jar"
 
-    if(file(deobfFile).exists()) {
+    if (file(deobfFile).exists()) {
         return files(deobfFile)
     }
 
+    String mappingsVer
+    String remoteMappings = project.hasProperty('remoteMappings') ? project.remoteMappings : 'https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/'
+    if (remoteMappings) {
+        String id = "${forgeVersion.split("\\.")[3]}-$minecraftVersion"
+        String mappingsZIP = "$cacheDir/forge_gradle/maven_downloader/de/oceanlabs/mcp/mcp_snapshot_nodoc/$id/mcp_snapshot_nodoc-${id}.zip"
+
+        zipMappings(mappingsZIP, remoteMappings, bon2Dir)
+
+        mappingsVer = "snapshot_$id"
+    } else {
+        mappingsVer = "${channel}_$mappingsVersion"
+    }
+
     download.run {
-        src 'https://github.com/GTNewHorizons/BON2/releases/download/2.5.0/BON2-2.5.0.CUSTOM-all.jar'
+        src "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/parker8283/BON2/$bon2Version-CUSTOM/BON2-$bon2Version-CUSTOM-all.jar"
         dest bon2File
         quiet true
         overwrite false
@@ -726,12 +1025,46 @@ def deobf(String sourceURL, String fileName) {
     }
 
     exec {
-        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12', '--notch'
+        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', minecraftVersion, '--mappingsVer', mappingsVer, '--notch'
         workingDir bon2Dir
-        standardOutput = new ByteArrayOutputStream()
+        standardOutput = new FileOutputStream("${deobfFile}.log")
     }
 
     return files(deobfFile)
+}
+
+def zipMappings(String zipPath, String url, String bon2Dir) {
+    File zipFile = new File(zipPath)
+    if (zipFile.exists()) {
+        return
+    }
+
+    String fieldsCache = "$bon2Dir/data/fields.csv"
+    String methodsCache = "$bon2Dir/data/methods.csv"
+
+    download.run {
+        src "${url}fields.csv"
+        dest fieldsCache
+        quiet true
+    }
+    download.run {
+        src "${url}methods.csv"
+        dest methodsCache
+        quiet true
+    }
+
+    zipFile.getParentFile().mkdirs()
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))
+
+    zos.putNextEntry(new ZipEntry("fields.csv"))
+    Files.copy(Paths.get(fieldsCache), zos)
+    zos.closeEntry()
+
+    zos.putNextEntry(new ZipEntry("methods.csv"))
+    Files.copy(Paths.get(methodsCache), zos)
+    zos.closeEntry()
+
+    zos.close()
 }
 
 // Helper methods
@@ -742,6 +1075,21 @@ def checkPropertyExists(String propertyName) {
     }
 }
 
+def propertyDefaultIfUnset(String propertyName, defaultValue) {
+    if (!project.hasProperty(propertyName) || project.property(propertyName) == "") {
+        project.ext.setProperty(propertyName, defaultValue)
+    }
+}
+
 def getFile(String relativePath) {
     return new File(projectDir, relativePath)
+}
+
+def getSecondaryArtifacts() {
+    // Because noPublishedSources from the beginning of the script is somehow not visible here...
+    boolean noPublishedSources = project.hasProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
+    def secondaryArtifacts = [devJar]
+    if (!noPublishedSources) secondaryArtifacts += [sourcesJar]
+    if (apiPackage) secondaryArtifacts += [apiJar]
+    return secondaryArtifacts
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -7,6 +7,17 @@ repositories {
         allowInsecureProtocol
     }
     maven {
+        url "https://cursemaven.com"
+    }
+    maven {
+        name = "ic2"
+        url = "http://maven.ic2.player.to/"
+        metadataSources {
+            mavenPom()
+            artifact()
+        }
+    }
+    maven {
         name = "jitpack"
         url = "https://jitpack.io"
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id 'com.diffplug.blowdryerSetup' version '1.6.0'
+}
+
+apply plugin: 'com.diffplug.blowdryerSetup'
+
+blowdryerSetup {
+    github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.1.5')
+    //devLocal '.' // Use this when testing config updates locally
+}

--- a/src/main/java/bq_standard/AdminExecute.java
+++ b/src/main/java/bq_standard/AdminExecute.java
@@ -9,48 +9,40 @@ import net.minecraft.world.World;
 /**
  * Elevates the player's privileges to OP level for use in command rewards
  */
-public class AdminExecute implements ICommandSender
-{
-	private final EntityPlayer player;
-	
-	public AdminExecute(EntityPlayer player)
-	{
-		this.player = player;
-	}
+public class AdminExecute implements ICommandSender {
+    private final EntityPlayer player;
 
-	@Override
-	public String getCommandSenderName()
-	{
-		return player.getCommandSenderName();
-	}
+    public AdminExecute(EntityPlayer player) {
+        this.player = player;
+    }
 
-	@Override
-	public IChatComponent func_145748_c_()
-	{
-		return player.func_145748_c_();
-	}
+    @Override
+    public String getCommandSenderName() {
+        return player.getCommandSenderName();
+    }
 
-	@Override
-	public void addChatMessage(IChatComponent p_145747_1_)
-	{
-		player.addChatMessage(p_145747_1_);
-	}
+    @Override
+    public IChatComponent func_145748_c_() {
+        return player.func_145748_c_();
+    }
 
-	@Override
-	public boolean canCommandSenderUseCommand(int p_70003_1_, String p_70003_2_)
-	{
-		return true;
-	}
+    @Override
+    public void addChatMessage(IChatComponent p_145747_1_) {
+        player.addChatMessage(p_145747_1_);
+    }
 
-	@Override
-	public ChunkCoordinates getPlayerCoordinates()
-	{
-		return player.getPlayerCoordinates();
-	}
+    @Override
+    public boolean canCommandSenderUseCommand(int p_70003_1_, String p_70003_2_) {
+        return true;
+    }
 
-	@Override
-	public World getEntityWorld()
-	{
-		return player.getEntityWorld();
-	}
+    @Override
+    public ChunkCoordinates getPlayerCoordinates() {
+        return player.getPlayerCoordinates();
+    }
+
+    @Override
+    public World getEntityWorld() {
+        return player.getEntityWorld();
+    }
 }

--- a/src/main/java/bq_standard/NBTReplaceUtil.java
+++ b/src/main/java/bq_standard/NBTReplaceUtil.java
@@ -1,47 +1,38 @@
 package bq_standard;
 
 import betterquesting.api.utils.NBTConverter;
+import java.util.List;
+import java.util.Set;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
 
-import java.util.List;
-import java.util.Set;
+public class NBTReplaceUtil {
+    @SuppressWarnings("unchecked")
+    public static <T extends NBTBase> T replaceStrings(T baseTag, String key, String replace) {
+        if (baseTag == null) {
+            return null;
+        }
 
-public class NBTReplaceUtil
-{
-	@SuppressWarnings("unchecked")
-	public static <T extends NBTBase> T replaceStrings(T baseTag, String key, String replace)
-	{
-		if(baseTag == null)
-		{
-			return null;
-		}
-		
-		if(baseTag instanceof NBTTagCompound)
-		{
-			NBTTagCompound compound = (NBTTagCompound)baseTag;
-			
-			for(String k : (Set<String>)compound.func_150296_c())
-			{
-				compound.setTag(k, replaceStrings(compound.getTag(k), key, replace));
-			}
-		} else if(baseTag instanceof NBTTagList)
-		{
-			NBTTagList list = (NBTTagList)baseTag;
-			List<NBTBase> tList = NBTConverter.getTagList(list);
-			
-			for(int i = 0; i < tList.size(); i++)
-			{
-				tList.set(i, replaceStrings(tList.get(i), key, replace));
-			}
-		} else if(baseTag instanceof NBTTagString)
-		{
-			NBTTagString tString = (NBTTagString)baseTag;
-			return (T)new NBTTagString(tString.func_150285_a_().replaceAll(key, replace));
-		}
-		
-		return baseTag; // Either isn't a string or doesn't contain one
-	}
+        if (baseTag instanceof NBTTagCompound) {
+            NBTTagCompound compound = (NBTTagCompound) baseTag;
+
+            for (String k : (Set<String>) compound.func_150296_c()) {
+                compound.setTag(k, replaceStrings(compound.getTag(k), key, replace));
+            }
+        } else if (baseTag instanceof NBTTagList) {
+            NBTTagList list = (NBTTagList) baseTag;
+            List<NBTBase> tList = NBTConverter.getTagList(list);
+
+            for (int i = 0; i < tList.size(); i++) {
+                tList.set(i, replaceStrings(tList.get(i), key, replace));
+            }
+        } else if (baseTag instanceof NBTTagString) {
+            NBTTagString tString = (NBTTagString) baseTag;
+            return (T) new NBTTagString(tString.func_150285_a_().replaceAll(key, replace));
+        }
+
+        return baseTag; // Either isn't a string or doesn't contain one
+    }
 }

--- a/src/main/java/bq_standard/NbtBlockType.java
+++ b/src/main/java/bq_standard/NbtBlockType.java
@@ -2,42 +2,36 @@ package bq_standard;
 
 import betterquesting.api.placeholders.ItemPlaceholder;
 import betterquesting.api.utils.BigItemStack;
+import javax.annotation.Nullable;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
 
-import javax.annotation.Nullable;
-
 public class NbtBlockType // TODO: Make a version of this for the base mod and give it a dedicated editor
-{
+ {
     public Block b = Blocks.log;
     public int m = -1;
     public int n = 1;
     public String oreDict = "";
     public NBTTagCompound tags = new NBTTagCompound();
-    
-    public NbtBlockType()
-    {
-    }
-    
-    public NbtBlockType(Block block)
-    {
+
+    public NbtBlockType() {}
+
+    public NbtBlockType(Block block) {
         this.b = block;
         this.oreDict = "";
         this.tags = new NBTTagCompound();
     }
-    
-    public NbtBlockType(Block block, int meta)
-    {
+
+    public NbtBlockType(Block block, int meta) {
         this.b = block;
         this.m = meta;
         this.oreDict = "";
         this.tags = new NBTTagCompound();
     }
-    
-    public NBTTagCompound writeToNBT(NBTTagCompound json)
-    {
+
+    public NBTTagCompound writeToNBT(NBTTagCompound json) {
         String bName = Block.blockRegistry.getNameForObject(b);
         json.setString("blockID", bName == null ? "" : bName);
         json.setInteger("meta", m);
@@ -46,31 +40,27 @@ public class NbtBlockType // TODO: Make a version of this for the base mod and g
         json.setString("oreDict", oreDict == null ? "" : oreDict);
         return json;
     }
-    
-    public void readFromNBT(NBTTagCompound json)
-    {
-        b = (Block)Block.blockRegistry.getObject(json.getString("blockID"));
+
+    public void readFromNBT(NBTTagCompound json) {
+        b = (Block) Block.blockRegistry.getObject(json.getString("blockID"));
         m = json.getInteger("meta");
         tags = json.getCompoundTag("nbt");
         n = json.getInteger("amount");
         oreDict = json.getString("oreDict");
     }
-    
+
     @Nullable
-    public BigItemStack getItemStack()
-    {
+    public BigItemStack getItemStack() {
         BigItemStack stack;
-        
-        if(b == null)
-        {
+
+        if (b == null) {
             stack = new BigItemStack(ItemPlaceholder.placeholder, n, m);
             stack.getBaseStack().setStackDisplayName("NULL");
-        } else
-        {
-            if(Item.getItemFromBlock(b) == null) return null;
+        } else {
+            if (Item.getItemFromBlock(b) == null) return null;
             stack = new BigItemStack(b, n, m);
         }
-        
+
         stack.setOreDict(oreDict);
         return stack;
     }

--- a/src/main/java/bq_standard/ScoreBQ.java
+++ b/src/main/java/bq_standard/ScoreBQ.java
@@ -1,64 +1,55 @@
 package bq_standard;
 
 import betterquesting.api2.storage.INBTPartial;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 
-public class ScoreBQ implements INBTPartial<NBTTagList, UUID>
-{
-	private final TreeMap<UUID, Integer> playerScores = new TreeMap<>();
-	
-	public synchronized int getScore(@Nonnull UUID uuid)
-	{
-		Integer value = playerScores.get(uuid);
-		return value == null? 0 : value;
-	}
-	
-	public synchronized void setScore(@Nonnull UUID uuid, int value)
-	{
-		playerScores.put(uuid, value);
-	}
-	
-	public synchronized boolean hasEntry(@Nonnull UUID uuid)
-    {
+public class ScoreBQ implements INBTPartial<NBTTagList, UUID> {
+    private final TreeMap<UUID, Integer> playerScores = new TreeMap<>();
+
+    public synchronized int getScore(@Nonnull UUID uuid) {
+        Integer value = playerScores.get(uuid);
+        return value == null ? 0 : value;
+    }
+
+    public synchronized void setScore(@Nonnull UUID uuid, int value) {
+        playerScores.put(uuid, value);
+    }
+
+    public synchronized boolean hasEntry(@Nonnull UUID uuid) {
         return playerScores.containsKey(uuid);
     }
-	
-	@Override
-	public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset)
-	{
-		for(Entry<UUID, Integer> entry : playerScores.entrySet())
-		{
-		    if(subset != null && !subset.contains(entry.getKey())) continue;
-			NBTTagCompound jObj = new NBTTagCompound();
-			jObj.setString("uuid", entry.getKey().toString());
-			jObj.setInteger("value", entry.getValue());
-			nbt.appendTag(jObj);
-		}
-		
-		return nbt;
-	}
-	
-	@Override
-	public synchronized void readFromNBT(NBTTagList nbt, boolean merge)
-	{
-        if(!merge) playerScores.clear();
-		
-		for(int i = 0; i < nbt.tagCount(); i++)
-		{
-			try
-			{
-			    NBTTagCompound tag = nbt.getCompoundTagAt(i);
-				playerScores.put(UUID.fromString(tag.getString("uuid")), tag.getInteger("value"));
-				
-			} catch(Exception ignored){}
-		}
-	}
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) {
+        for (Entry<UUID, Integer> entry : playerScores.entrySet()) {
+            if (subset != null && !subset.contains(entry.getKey())) continue;
+            NBTTagCompound jObj = new NBTTagCompound();
+            jObj.setString("uuid", entry.getKey().toString());
+            jObj.setInteger("value", entry.getValue());
+            nbt.appendTag(jObj);
+        }
+
+        return nbt;
+    }
+
+    @Override
+    public synchronized void readFromNBT(NBTTagList nbt, boolean merge) {
+        if (!merge) playerScores.clear();
+
+        for (int i = 0; i < nbt.tagCount(); i++) {
+            try {
+                NBTTagCompound tag = nbt.getCompoundTagAt(i);
+                playerScores.put(UUID.fromString(tag.getString("uuid")), tag.getInteger("value"));
+
+            } catch (Exception ignored) {
+            }
+        }
+    }
 }

--- a/src/main/java/bq_standard/ScoreboardBQ.java
+++ b/src/main/java/bq_standard/ScoreboardBQ.java
@@ -1,57 +1,49 @@
 package bq_standard;
 
 import betterquesting.api2.storage.INBTPartial;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 
-public class ScoreboardBQ implements INBTPartial<NBTTagList, UUID>
-{
+public class ScoreboardBQ implements INBTPartial<NBTTagList, UUID> {
     public static final ScoreboardBQ INSTANCE = new ScoreboardBQ();
-    
-	private final TreeMap<String, ScoreBQ> objectives = new TreeMap<>();
-	
-	public synchronized int getScore(@Nonnull UUID uuid, @Nonnull String scoreName)
-	{
-		ScoreBQ score = objectives.get(scoreName);
-		return score == null ? 0 : score.getScore(uuid);
-	}
-	
-	public synchronized void setScore(@Nonnull UUID uuid, @Nonnull String scoreName, int value)
-	{
-		ScoreBQ score = objectives.computeIfAbsent(scoreName, (key) -> new ScoreBQ());
-		score.setScore(uuid, value);
-	}
-	
-	@Override
-	public synchronized void readFromNBT(NBTTagList nbt, boolean merge)
-	{
-        if(!merge) objectives.clear();
-		for(int i = 0; i < nbt.tagCount(); i++)
-		{
-			NBTTagCompound jObj = nbt.getCompoundTagAt(i);
-			ScoreBQ score = objectives.computeIfAbsent(jObj.getString("name"), (key) -> new ScoreBQ());
-			score.readFromNBT(jObj.getTagList("scores", 10), merge);
-		}
-	}
-	
-	@Override
-	public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset)
-	{
-		for(Entry<String,ScoreBQ> entry : objectives.entrySet())
-		{
-			NBTTagCompound jObj = new NBTTagCompound();
-			jObj.setString("name", entry.getKey());
-			jObj.setTag("scores", entry.getValue().writeToNBT(new NBTTagList(), subset));
-			nbt.appendTag(jObj);
-		}
-		
-		return nbt;
-	}
+
+    private final TreeMap<String, ScoreBQ> objectives = new TreeMap<>();
+
+    public synchronized int getScore(@Nonnull UUID uuid, @Nonnull String scoreName) {
+        ScoreBQ score = objectives.get(scoreName);
+        return score == null ? 0 : score.getScore(uuid);
+    }
+
+    public synchronized void setScore(@Nonnull UUID uuid, @Nonnull String scoreName, int value) {
+        ScoreBQ score = objectives.computeIfAbsent(scoreName, (key) -> new ScoreBQ());
+        score.setScore(uuid, value);
+    }
+
+    @Override
+    public synchronized void readFromNBT(NBTTagList nbt, boolean merge) {
+        if (!merge) objectives.clear();
+        for (int i = 0; i < nbt.tagCount(); i++) {
+            NBTTagCompound jObj = nbt.getCompoundTagAt(i);
+            ScoreBQ score = objectives.computeIfAbsent(jObj.getString("name"), (key) -> new ScoreBQ());
+            score.readFromNBT(jObj.getTagList("scores", 10), merge);
+        }
+    }
+
+    @Override
+    public synchronized NBTTagList writeToNBT(NBTTagList nbt, @Nullable List<UUID> subset) {
+        for (Entry<String, ScoreBQ> entry : objectives.entrySet()) {
+            NBTTagCompound jObj = new NBTTagCompound();
+            jObj.setString("name", entry.getKey());
+            jObj.setTag("scores", entry.getValue().writeToNBT(new NBTTagList(), subset));
+            nbt.appendTag(jObj);
+        }
+
+        return nbt;
+    }
 }

--- a/src/main/java/bq_standard/XPHelper.java
+++ b/src/main/java/bq_standard/XPHelper.java
@@ -4,90 +4,76 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.play.server.S1FPacketSetExperience;
 
-public class XPHelper
-{
-	// Pre-calculated XP levels at 1M intervals for speed searching
-	private static long[] QUICK_XP = new long[2147];
-	
-	static
-	{
-		for(int i = 0; i < QUICK_XP.length; i++)
-		{
-			QUICK_XP[i] = getLevelXP(i * 1000000);
-		}
-	}
-	
-	public static void addXP(EntityPlayer player, long xp)
-	{
-		addXP(player, xp, true);
-	}
-	
-	public static void addXP(EntityPlayer player, long xp, boolean sync)
-	{
-		long experience = getPlayerXP(player) + xp;
-		player.experienceTotal = experience >= Integer.MAX_VALUE? Integer.MAX_VALUE : (int)experience;
-		player.experienceLevel = getXPLevel(experience);
-		long expForLevel = getLevelXP(player.experienceLevel);
-		player.experience = (float)((double)(experience - expForLevel) / (double)xpBarCap(player));
-		player.experience = Math.max(0F, player.experience); // Sanity check
-		
-		if(sync && player instanceof EntityPlayerMP) syncXP((EntityPlayerMP)player);
-	}
-	
-	public static void syncXP(EntityPlayerMP player)
-	{
-		// Make sure the client isn't being stupid about syncing the experience bars which routinely fail
-        player.playerNetServerHandler.sendPacket(new S1FPacketSetExperience(player.experience, player.experienceTotal, player.experienceLevel));
-	}
-	
-	public static long getPlayerXP(EntityPlayer player)
-	{
-	    // Math.max is used here because for some reason the player.experience float value can sometimes be negitive in error
-		return getLevelXP(player.experienceLevel) + (long)(xpBarCap(player) * Math.max(0D, player.experience));
-	}
-	
-	public static long xpBarCap(EntityPlayer player)
-	{
-		if(player.experienceLevel < 16)
-		{
-			return (long)(2D * player.experienceLevel + 7L);
-		} else if(player.experienceLevel < 31)
-		{
-			return (long)(5D * player.experienceLevel - 38L);
-		} else
-		{
-			return (long)(9D * player.experienceLevel - 158L);
-		}
-	}
-	
-	public static int getXPLevel(long xp)
-	{
-		if(xp <= 0) return 0;
-		
-		int i = 0;
-		
-		while(i < QUICK_XP.length && QUICK_XP[i] <= xp) i++;
-		
-		if(i > 0) i = (i - 1) * 1000000;
-		
-		while (i < Integer.MAX_VALUE && getLevelXP(i) <= xp) i++;
-		
-		return i - 1;
-	}
-	
-	public static long getLevelXP(int level)
-	{
-		if(level <= 0) return 0;
-		
-		if(level < 16)
-		{
-			return level * 17;
-		} else if(level < 31)
-		{
-			return (long)(1.5D * Math.pow(level, 2D) - (29.5D * level) + 360L);
-		} else
-		{
-			return (long)(3.5D * Math.pow(level, 2D) - (151.5D * level) + 2220L);
-		}
-	}
+public class XPHelper {
+    // Pre-calculated XP levels at 1M intervals for speed searching
+    private static long[] QUICK_XP = new long[2147];
+
+    static {
+        for (int i = 0; i < QUICK_XP.length; i++) {
+            QUICK_XP[i] = getLevelXP(i * 1000000);
+        }
+    }
+
+    public static void addXP(EntityPlayer player, long xp) {
+        addXP(player, xp, true);
+    }
+
+    public static void addXP(EntityPlayer player, long xp, boolean sync) {
+        long experience = getPlayerXP(player) + xp;
+        player.experienceTotal = experience >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) experience;
+        player.experienceLevel = getXPLevel(experience);
+        long expForLevel = getLevelXP(player.experienceLevel);
+        player.experience = (float) ((double) (experience - expForLevel) / (double) xpBarCap(player));
+        player.experience = Math.max(0F, player.experience); // Sanity check
+
+        if (sync && player instanceof EntityPlayerMP) syncXP((EntityPlayerMP) player);
+    }
+
+    public static void syncXP(EntityPlayerMP player) {
+        // Make sure the client isn't being stupid about syncing the experience bars which routinely fail
+        player.playerNetServerHandler.sendPacket(
+                new S1FPacketSetExperience(player.experience, player.experienceTotal, player.experienceLevel));
+    }
+
+    public static long getPlayerXP(EntityPlayer player) {
+        // Math.max is used here because for some reason the player.experience float value can sometimes be negitive in
+        // error
+        return getLevelXP(player.experienceLevel) + (long) (xpBarCap(player) * Math.max(0D, player.experience));
+    }
+
+    public static long xpBarCap(EntityPlayer player) {
+        if (player.experienceLevel < 16) {
+            return (long) (2D * player.experienceLevel + 7L);
+        } else if (player.experienceLevel < 31) {
+            return (long) (5D * player.experienceLevel - 38L);
+        } else {
+            return (long) (9D * player.experienceLevel - 158L);
+        }
+    }
+
+    public static int getXPLevel(long xp) {
+        if (xp <= 0) return 0;
+
+        int i = 0;
+
+        while (i < QUICK_XP.length && QUICK_XP[i] <= xp) i++;
+
+        if (i > 0) i = (i - 1) * 1000000;
+
+        while (i < Integer.MAX_VALUE && getLevelXP(i) <= xp) i++;
+
+        return i - 1;
+    }
+
+    public static long getLevelXP(int level) {
+        if (level <= 0) return 0;
+
+        if (level < 16) {
+            return level * 17;
+        } else if (level < 31) {
+            return (long) (1.5D * Math.pow(level, 2D) - (29.5D * level) + 360L);
+        } else {
+            return (long) (3.5D * Math.pow(level, 2D) - (151.5D * level) + 2220L);
+        }
+    }
 }

--- a/src/main/java/bq_standard/client/gui/GuiBQSConfig.java
+++ b/src/main/java/bq_standard/client/gui/GuiBQSConfig.java
@@ -6,18 +6,23 @@ import cpw.mods.fml.client.config.GuiConfig;
 import cpw.mods.fml.client.config.IConfigElement;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.List;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.common.config.Configuration;
 
-import java.util.List;
-
 @SideOnly(Side.CLIENT)
-public class GuiBQSConfig extends GuiConfig
-{
+public class GuiBQSConfig extends GuiConfig {
     @SuppressWarnings("unchecked")
-	public GuiBQSConfig(GuiScreen parent)
-	{
-		super(parent, (List<IConfigElement>)new ConfigElement(ConfigHandler.config.getCategory(Configuration.CATEGORY_GENERAL)).getChildElements(), BQ_Standard.MODID, false, false, BQ_Standard.NAME);
-	}
+    public GuiBQSConfig(GuiScreen parent) {
+        super(
+                parent,
+                (List<IConfigElement>)
+                        new ConfigElement(ConfigHandler.config.getCategory(Configuration.CATEGORY_GENERAL))
+                                .getChildElements(),
+                BQ_Standard.MODID,
+                false,
+                false,
+                BQ_Standard.NAME);
+    }
 }

--- a/src/main/java/bq_standard/client/gui/GuiContainerFake.java
+++ b/src/main/java/bq_standard/client/gui/GuiContainerFake.java
@@ -1,8 +1,7 @@
 package bq_standard.client.gui;
 
-import net.minecraft.client.gui.inventory.GuiContainer;
-
 import java.util.function.Consumer;
+import net.minecraft.client.gui.inventory.GuiContainer;
 
 public class GuiContainerFake extends GuiContainer {
     public GuiContainerFake() {
@@ -13,19 +12,14 @@ public class GuiContainerFake extends GuiContainer {
 
     @Override
     public void initGui() {
-        if (onInitCallback != null)
-            onInitCallback.accept(null);
+        if (onInitCallback != null) onInitCallback.accept(null);
     }
 
     @Override
-    public void onGuiClosed() {
-
-    }
+    public void onGuiClosed() {}
 
     @Override
-    protected void drawGuiContainerBackgroundLayer(float p_146976_1_, int p_146976_2_, int p_146976_3_) {
-
-    }
+    protected void drawGuiContainerBackgroundLayer(float p_146976_1_, int p_146976_2_, int p_146976_3_) {}
 
     public void setOnInitCallback(Consumer onInitCallback) {
         this.onInitCallback = onInitCallback;

--- a/src/main/java/bq_standard/client/gui/GuiLootChest.java
+++ b/src/main/java/bq_standard/client/gui/GuiLootChest.java
@@ -10,52 +10,53 @@ import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.resources.textures.IGuiTexture;
 import betterquesting.api2.utils.QuestTranslation;
 import bq_standard.client.theme.BQSTextures;
+import java.util.List;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.util.ResourceLocation;
 
-import java.util.List;
-
-public class GuiLootChest extends GuiScreenCanvas
-{
+public class GuiLootChest extends GuiScreenCanvas {
     private static final ResourceLocation SND_OPEN = new ResourceLocation("randmom.chestopen");
     private final String title;
     private final List<BigItemStack> rewards;
-    
-    public GuiLootChest(GuiScreen parent, List<BigItemStack> rewards, String title)
-    {
+
+    public GuiLootChest(GuiScreen parent, List<BigItemStack> rewards, String title) {
         super(parent);
         this.rewards = rewards;
         this.title = title;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-		
-		mc.getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(SND_OPEN, 1.0F));
-    
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.MID_CENTER, -64, 0, 128, 68, 0), BQSTextures.LOOT_CHEST.getTexture()));
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.MID_CENTER, -64, 40, 128, 56, -1), QuestTranslation.translate(title)).setAlignment(1));
-    
+
+        mc.getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(SND_OPEN, 1.0F));
+
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.MID_CENTER, -64, 0, 128, 68, 0), BQSTextures.LOOT_CHEST.getTexture()));
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.MID_CENTER, -64, 40, 128, 56, -1), QuestTranslation.translate(title))
+                .setAlignment(1));
+
         IGuiTexture texGlow = BQSTextures.LOOT_GLOW.getTexture();
-        int rowMax = (int)Math.ceil(rewards.size()/8F);
-        rowMax = rewards.size()/rowMax;
-        
-        for(int i = 0; i < rewards.size(); i++)
-        {
+        int rowMax = (int) Math.ceil(rewards.size() / 8F);
+        rowMax = rewards.size() / rowMax;
+
+        for (int i = 0; i < rewards.size(); i++) {
             BigItemStack stack = rewards.get(i);
-            
-            int rowX = i%rowMax;
-            int rowY = i/rowMax;
-            int rowSize = Math.min(rewards.size() - rowY*rowMax, rowMax);
-            
-            rowX = -(rowSize * 36)/2 + (rowX * 36);
+
+            int rowX = i % rowMax;
+            int rowY = i / rowMax;
+            int rowSize = Math.min(rewards.size() - rowY * rowMax, rowMax);
+
+            rowX = -(rowSize * 36) / 2 + (rowX * 36);
             rowY = -36 - (rowY * 36);
-            
-            this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.MID_CENTER, rowX + 2, rowY + 2, 32, 32, 0), texGlow));
-            this.addPanel(new PanelItemSlot(new GuiTransform(GuiAlign.MID_CENTER, rowX + 10, rowY + 10, 16, 16, -1), -1, stack).setTextures(null, null, null));
+
+            this.addPanel(
+                    new PanelGeneric(new GuiTransform(GuiAlign.MID_CENTER, rowX + 2, rowY + 2, 32, 32, 0), texGlow));
+            this.addPanel(new PanelItemSlot(
+                            new GuiTransform(GuiAlign.MID_CENTER, rowX + 10, rowY + 10, 16, 16, -1), -1, stack)
+                    .setTextures(null, null, null));
         }
     }
 }

--- a/src/main/java/bq_standard/client/gui/editors/GuiEditLootEntry.java
+++ b/src/main/java/bq_standard/client/gui/editors/GuiEditLootEntry.java
@@ -22,216 +22,238 @@ import bq_standard.network.handlers.NetLootImport;
 import bq_standard.rewards.loot.LootGroup;
 import bq_standard.rewards.loot.LootGroup.LootEntry;
 import bq_standard.rewards.loot.LootRegistry;
+import java.text.DecimalFormat;
+import java.util.List;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.util.vector.Vector4f;
 
-import java.text.DecimalFormat;
-import java.util.List;
-
-public class GuiEditLootEntry extends GuiScreenCanvas
-{
+public class GuiEditLootEntry extends GuiScreenCanvas {
     private LootGroup lootGroup;
     private final int groupID;
-    
+
     private LootEntry selEntry;
     private int selectedID = -1;
-    
+
     private CanvasScrolling lootList;
     private PanelTextBox fieldName;
     private PanelTextField<Integer> fieldWeight;
     private PanelTextBox textWeight;
-    
+
     private final DecimalFormat numFormat = new DecimalFormat("0.##");
-    
-    public GuiEditLootEntry(GuiScreen parent, LootGroup group)
-    {
+
+    public GuiEditLootEntry(GuiScreen parent, LootGroup group) {
         super(parent);
         this.lootGroup = group;
         this.groupID = LootRegistry.INSTANCE.getID(group);
         this.setVolatile(true);
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-    
+
         Keyboard.enableRepeatEvents(true);
-    
+
         CanvasTextured cvBackground = new CanvasTextured(new GuiTransform(), PresetTexture.PANEL_MAIN.getTexture());
         this.addPanel(cvBackground);
-    
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0), QuestTranslation.translate("bq_standard.title.edit_loot_groups")).setAlignment(1).setColor(PresetColor.TEXT_HEADER.getColor()));
-        
+
+        cvBackground.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0),
+                        QuestTranslation.translate("bq_standard.title.edit_loot_groups"))
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_HEADER.getColor()));
+
         // === LEFT SIDE ===
-    
+
         CanvasEmpty cvLeft = new CanvasEmpty(new GuiTransform(GuiAlign.HALF_LEFT, new GuiPadding(16, 32, 8, 24), 0));
         cvBackground.addPanel(cvLeft);
-        
+
         lootList = new CanvasScrolling(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(0, 0, 8, 24), 0));
         cvLeft.addPanel(lootList);
-    
-        PanelVScrollBar scList = new PanelVScrollBar(new GuiTransform(GuiAlign.RIGHT_EDGE, new GuiPadding(-8, 0, 0, 24), 0));
+
+        PanelVScrollBar scList =
+                new PanelVScrollBar(new GuiTransform(GuiAlign.RIGHT_EDGE, new GuiPadding(-8, 0, 0, 24), 0));
         cvLeft.addPanel(scList);
         lootList.setScrollDriverY(scList);
-    
-        cvLeft.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_EDGE, new GuiPadding(0, -16, 0, 0), 0), -1, QuestTranslation.translate("betterquesting.btn.new"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                lootGroup.add(lootGroup.nextID(), new LootEntry());
-                sendChanges();
-            }
-        });
-        
+
+        cvLeft.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_EDGE, new GuiPadding(0, -16, 0, 0), 0),
+                        -1,
+                        QuestTranslation.translate("betterquesting.btn.new")) {
+                    @Override
+                    public void onButtonClick() {
+                        lootGroup.add(lootGroup.nextID(), new LootEntry());
+                        sendChanges();
+                    }
+                });
+
         // === RIGHT SIDE ==
-        
+
         CanvasEmpty cvRight = new CanvasEmpty(new GuiTransform(GuiAlign.HALF_RIGHT, new GuiPadding(8, 32, 16, 24), 0));
         cvBackground.addPanel(cvRight);
-        
-        cvRight.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 4, 0, -16), 0), QuestTranslation.translate("betterquesting.gui.name")).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        fieldName = new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0), selEntry != null ? "#" + selectedID : "#--").setColor(PresetColor.TEXT_MAIN.getColor());
+
+        cvRight.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 4, 0, -16), 0),
+                        QuestTranslation.translate("betterquesting.gui.name"))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        fieldName = new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0),
+                        selEntry != null ? "#" + selectedID : "#--")
+                .setColor(PresetColor.TEXT_MAIN.getColor());
         cvRight.addPanel(fieldName);
-        
-        cvRight.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 36, 0, -48), 0), QuestTranslation.translate("bq_standard.gui.weight")).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        fieldWeight = new PanelTextField<>(new GuiTransform(new Vector4f(0F, 0F, 0.5F, 0F), new GuiPadding(0, 48, 0, -64), 0), "" + (selEntry != null ? selEntry.weight : 1), FieldFilterNumber.INT);
-        fieldWeight.setCallback(value ->
-        {
-            if(selEntry == null) return;
-            if(fieldWeight.getValue() <= 0) fieldWeight.setText("1");
+
+        cvRight.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 36, 0, -48), 0),
+                        QuestTranslation.translate("bq_standard.gui.weight"))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        fieldWeight = new PanelTextField<>(
+                new GuiTransform(new Vector4f(0F, 0F, 0.5F, 0F), new GuiPadding(0, 48, 0, -64), 0),
+                "" + (selEntry != null ? selEntry.weight : 1),
+                FieldFilterNumber.INT);
+        fieldWeight.setCallback(value -> {
+            if (selEntry == null) return;
+            if (fieldWeight.getValue() <= 0) fieldWeight.setText("1");
             selEntry.weight = fieldWeight.getValue();
             int totalWeight = lootGroup.getTotalWeight();
-            float chance = selEntry.weight / (float)totalWeight * 100F;
+            float chance = selEntry.weight / (float) totalWeight * 100F;
             textWeight.setText("/" + totalWeight + " (" + numFormat.format(chance) + "%)");
         });
         cvRight.addPanel(fieldWeight);
-        
-        textWeight = new PanelTextBox(new GuiTransform(new Vector4f(0.5F, 0F, 1F, 0F), new GuiPadding(4, 52, 0, -64), 0), "/1 (100%)").setColor(PresetColor.TEXT_MAIN.getColor());
+
+        textWeight = new PanelTextBox(
+                        new GuiTransform(new Vector4f(0.5F, 0F, 1F, 0F), new GuiPadding(4, 52, 0, -64), 0), "/1 (100%)")
+                .setColor(PresetColor.TEXT_MAIN.getColor());
         cvRight.addPanel(textWeight);
-        
+
         final GuiScreen screenRef = this;
-        cvRight.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_EDGE, new GuiPadding(0, -16, 0, 0), 0), -1, QuestTranslation.translate("bq_standard.btn.add_remove_drops"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                if(selEntry != null)
-                {
-                    final NBTTagCompound eTag = selEntry.writeToNBT(new NBTTagCompound());
-                    mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, eTag.getTagList("items", 10), value -> {
-                        LootGroup lg = LootRegistry.INSTANCE.getValue(groupID);
-                        LootEntry le = lg == null ? null : lg.getValue(selectedID);
-                        if(le != null)
-                        {
-                            le.readFromNBT(eTag);
-                            sendChanges();
+        cvRight.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_EDGE, new GuiPadding(0, -16, 0, 0), 0),
+                        -1,
+                        QuestTranslation.translate("bq_standard.btn.add_remove_drops")) {
+                    @Override
+                    public void onButtonClick() {
+                        if (selEntry != null) {
+                            final NBTTagCompound eTag = selEntry.writeToNBT(new NBTTagCompound());
+                            mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                                    .getGui(
+                                            PresetGUIs.EDIT_NBT,
+                                            new GArgsNBT<>(
+                                                    screenRef,
+                                                    eTag.getTagList("items", 10),
+                                                    value -> {
+                                                        LootGroup lg = LootRegistry.INSTANCE.getValue(groupID);
+                                                        LootEntry le = lg == null ? null : lg.getValue(selectedID);
+                                                        if (le != null) {
+                                                            le.readFromNBT(eTag);
+                                                            sendChanges();
+                                                        }
+                                                    },
+                                                    null)));
                         }
-                    }, null)));
-                }
-            }
-        });
-        
+                    }
+                });
+
         // === MISC ===
-        
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0), -1, QuestTranslation.translate("gui.done"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                sendChanges();
-                mc.displayGuiScreen(parent);
-            }
-        });
-        
+
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("gui.done")) {
+                    @Override
+                    public void onButtonClick() {
+                        sendChanges();
+                        mc.displayGuiScreen(parent);
+                    }
+                });
+
         // === DIVIDERS ===
-        
-		IGuiRect ls0 = new GuiTransform(GuiAlign.TOP_CENTER, 0, 32, 0, 0, 0);
-		ls0.setParent(cvBackground.getTransform());
-		IGuiRect le0 = new GuiTransform(GuiAlign.BOTTOM_CENTER, 0, -24, 0, 0, 0);
-		le0.setParent(cvBackground.getTransform());
-		PanelLine paLine0 = new PanelLine(ls0, le0, PresetLine.GUI_DIVIDER.getLine(), 1, PresetColor.GUI_DIVIDER.getColor(), 1);
-		cvBackground.addPanel(paLine0);
-        
+
+        IGuiRect ls0 = new GuiTransform(GuiAlign.TOP_CENTER, 0, 32, 0, 0, 0);
+        ls0.setParent(cvBackground.getTransform());
+        IGuiRect le0 = new GuiTransform(GuiAlign.BOTTOM_CENTER, 0, -24, 0, 0, 0);
+        le0.setParent(cvBackground.getTransform());
+        PanelLine paLine0 =
+                new PanelLine(ls0, le0, PresetLine.GUI_DIVIDER.getLine(), 1, PresetColor.GUI_DIVIDER.getColor(), 1);
+        cvBackground.addPanel(paLine0);
+
         refreshEntries();
     }
-    
+
     @Override
-    public void drawPanel(int mx, int my, float partialTick)
-    {
-        if(LootRegistry.INSTANCE.updateUI)
-        {
+    public void drawPanel(int mx, int my, float partialTick) {
+        if (LootRegistry.INSTANCE.updateUI) {
             LootRegistry.INSTANCE.updateUI = false;
             lootGroup = LootRegistry.INSTANCE.getValue(groupID);
-            if(lootGroup == null)
-            {
+            if (lootGroup == null) {
                 mc.displayGuiScreen(parent);
                 return;
             }
-            
-            if(selectedID >= 0)
-            {
+
+            if (selectedID >= 0) {
                 selEntry = lootGroup.getValue(selectedID);
-                
-                if(selEntry == null)
-                {
+
+                if (selEntry == null) {
                     selectedID = -1;
-                    
+
                     fieldName.setText("");
                     fieldWeight.setText("1");
                     textWeight.setText("/1 (100%)");
-                } else
-                {
+                } else {
                     selEntry.weight = fieldWeight.getValue();
-                    
+
                     int totalWeight = lootGroup.getTotalWeight();
-                    float chance = selEntry.weight / (float)totalWeight * 100F;
+                    float chance = selEntry.weight / (float) totalWeight * 100F;
                     textWeight.setText("/" + totalWeight + " (" + numFormat.format(chance) + "%)");
                 }
             }
-            
+
             refreshEntries();
         }
-        
+
         super.drawPanel(mx, my, partialTick);
     }
-    
-    private void refreshEntries()
-    {
+
+    private void refreshEntries() {
         lootList.resetCanvas();
         int lWidth = lootList.getTransform().getWidth();
         final List<DBEntry<LootEntry>> lgAry = lootGroup.getEntries();
-        
-        for(int i = 0; i < lgAry.size(); i++)
-        {
-            lootList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 16, 16, 0), -1, "", lgAry.get(i)).setCallback(value ->
-            {
-                lootGroup.removeID(value.getID());
-                refreshEntries();
-                sendChanges();
-            }).setIcon(PresetIcon.ICON_TRASH.getTexture()));
-            
-            lootList.addPanel(new PanelButtonStorage<>(new GuiRectangle(16, i * 16, lWidth - 16, 16, 0), -1, "#" + lgAry.get(i).getID(), lgAry.get(i)).setCallback(value ->
-            {
-                if(selEntry != null) sendChanges();
-                selectedID = value.getID();
-                selEntry = value.getValue();
-                fieldName.setText("#" + selectedID);
-                fieldWeight.setText("" + selEntry.weight);
-                
-                int totalWeight = lootGroup.getTotalWeight();
-                float chance = selEntry.weight / (float)totalWeight * 100F;
-                textWeight.setText("/" + totalWeight + " (" + numFormat.format(chance) + "%)");
-            }));
+
+        for (int i = 0; i < lgAry.size(); i++) {
+            lootList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 16, 16, 0), -1, "", lgAry.get(i))
+                    .setCallback(value -> {
+                        lootGroup.removeID(value.getID());
+                        refreshEntries();
+                        sendChanges();
+                    })
+                    .setIcon(PresetIcon.ICON_TRASH.getTexture()));
+
+            lootList.addPanel(new PanelButtonStorage<>(
+                            new GuiRectangle(16, i * 16, lWidth - 16, 16, 0),
+                            -1,
+                            "#" + lgAry.get(i).getID(),
+                            lgAry.get(i))
+                    .setCallback(value -> {
+                        if (selEntry != null) sendChanges();
+                        selectedID = value.getID();
+                        selEntry = value.getValue();
+                        fieldName.setText("#" + selectedID);
+                        fieldWeight.setText("" + selEntry.weight);
+
+                        int totalWeight = lootGroup.getTotalWeight();
+                        float chance = selEntry.weight / (float) totalWeight * 100F;
+                        textWeight.setText("/" + totalWeight + " (" + numFormat.format(chance) + "%)");
+                    }));
         }
     }
-    
-    private void sendChanges()
-    {
+
+    private void sendChanges() {
         NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
     }
 }

--- a/src/main/java/bq_standard/client/gui/editors/GuiEditLootGroup.java
+++ b/src/main/java/bq_standard/client/gui/editors/GuiEditLootGroup.java
@@ -22,205 +22,221 @@ import betterquesting.api2.utils.QuestTranslation;
 import bq_standard.network.handlers.NetLootImport;
 import bq_standard.rewards.loot.LootGroup;
 import bq_standard.rewards.loot.LootRegistry;
+import java.text.DecimalFormat;
+import java.util.List;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.util.vector.Vector4f;
 
-import java.text.DecimalFormat;
-import java.util.List;
-
-public class GuiEditLootGroup extends GuiScreenCanvas
-{
+public class GuiEditLootGroup extends GuiScreenCanvas {
     private LootGroup selGroup;
     private int selectedID = -1;
-    
+
     private CanvasScrolling lootList;
     private PanelTextField<String> fieldName;
     private PanelTextField<Integer> fieldWeight;
     private PanelTextBox textWeight;
-    
+
     private final DecimalFormat numFormat = new DecimalFormat("0.##");
-    
-    public GuiEditLootGroup(GuiScreen parent)
-    {
+
+    public GuiEditLootGroup(GuiScreen parent) {
         super(parent);
         this.setVolatile(true);
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-    
+
         Keyboard.enableRepeatEvents(true);
-    
+
         CanvasTextured cvBackground = new CanvasTextured(new GuiTransform(), PresetTexture.PANEL_MAIN.getTexture());
         this.addPanel(cvBackground);
-    
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0), QuestTranslation.translate("bq_standard.title.edit_loot_groups")).setAlignment(1).setColor(PresetColor.TEXT_HEADER.getColor()));
-        
+
+        cvBackground.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0),
+                        QuestTranslation.translate("bq_standard.title.edit_loot_groups"))
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_HEADER.getColor()));
+
         // === LEFT SIDE ===
-    
+
         CanvasEmpty cvLeft = new CanvasEmpty(new GuiTransform(GuiAlign.HALF_LEFT, new GuiPadding(16, 32, 8, 24), 0));
         cvBackground.addPanel(cvLeft);
-        
+
         lootList = new CanvasScrolling(new GuiTransform(GuiAlign.FULL_BOX, new GuiPadding(0, 0, 8, 24), 0));
         cvLeft.addPanel(lootList);
-    
-        PanelVScrollBar scList = new PanelVScrollBar(new GuiTransform(GuiAlign.RIGHT_EDGE, new GuiPadding(-8, 0, 0, 24), 0));
+
+        PanelVScrollBar scList =
+                new PanelVScrollBar(new GuiTransform(GuiAlign.RIGHT_EDGE, new GuiPadding(-8, 0, 0, 24), 0));
         cvLeft.addPanel(scList);
         lootList.setScrollDriverY(scList);
-    
-        cvLeft.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_EDGE, new GuiPadding(0, -16, 0, 0), 0), -1, QuestTranslation.translate("betterquesting.btn.new"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                LootRegistry.INSTANCE.add(LootRegistry.INSTANCE.nextID(), new LootGroup());
-                SendChanges();
-            }
-        });
-        
+
+        cvLeft.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_EDGE, new GuiPadding(0, -16, 0, 0), 0),
+                        -1,
+                        QuestTranslation.translate("betterquesting.btn.new")) {
+                    @Override
+                    public void onButtonClick() {
+                        LootRegistry.INSTANCE.add(LootRegistry.INSTANCE.nextID(), new LootGroup());
+                        SendChanges();
+                    }
+                });
+
         // === RIGHT SIDE ==
-        
+
         CanvasEmpty cvRight = new CanvasEmpty(new GuiTransform(GuiAlign.HALF_RIGHT, new GuiPadding(8, 32, 16, 24), 0));
         cvBackground.addPanel(cvRight);
-        
-        cvRight.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 4, 0, -16), 0), QuestTranslation.translate("betterquesting.gui.name")).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        fieldName = new PanelTextField<>(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0), selGroup != null ? selGroup.name : "", FieldFilterString.INSTANCE);
-        fieldName.setCallback(value ->
-        {
-            if(selGroup == null) return;
+
+        cvRight.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 4, 0, -16), 0),
+                        QuestTranslation.translate("betterquesting.gui.name"))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        fieldName = new PanelTextField<>(
+                new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 16, 0, -32), 0),
+                selGroup != null ? selGroup.name : "",
+                FieldFilterString.INSTANCE);
+        fieldName.setCallback(value -> {
+            if (selGroup == null) return;
             selGroup.name = fieldName.getValue();
             refreshGroups();
         });
         cvRight.addPanel(fieldName);
-        
-        cvRight.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 36, 0, -48), 0), QuestTranslation.translate("bq_standard.gui.weight")).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        fieldWeight = new PanelTextField<>(new GuiTransform(new Vector4f(0F, 0F, 0.5F, 0F), new GuiPadding(0, 48, 0, -64), 0), "" + (selGroup != null ? selGroup.weight : 1), FieldFilterNumber.INT);
-        fieldWeight.setCallback(value ->
-        {
-            if(selGroup == null) return;
-            if(fieldWeight.getValue() <= 0) fieldWeight.setText("1");
+
+        cvRight.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(0, 36, 0, -48), 0),
+                        QuestTranslation.translate("bq_standard.gui.weight"))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        fieldWeight = new PanelTextField<>(
+                new GuiTransform(new Vector4f(0F, 0F, 0.5F, 0F), new GuiPadding(0, 48, 0, -64), 0),
+                "" + (selGroup != null ? selGroup.weight : 1),
+                FieldFilterNumber.INT);
+        fieldWeight.setCallback(value -> {
+            if (selGroup == null) return;
+            if (fieldWeight.getValue() <= 0) fieldWeight.setText("1");
             selGroup.weight = fieldWeight.getValue();
             int totalWeight = LootRegistry.INSTANCE.getTotalWeight();
-            float chance = selGroup.weight / (float)totalWeight * 100F;
+            float chance = selGroup.weight / (float) totalWeight * 100F;
             textWeight.setText("/" + totalWeight + " (" + numFormat.format(chance) + "%)");
         });
         cvRight.addPanel(fieldWeight);
-        
-        textWeight = new PanelTextBox(new GuiTransform(new Vector4f(0.5F, 0F, 1F, 0F), new GuiPadding(4, 52, 0, -64), 0), "/1 (100%)").setColor(PresetColor.TEXT_MAIN.getColor());
+
+        textWeight = new PanelTextBox(
+                        new GuiTransform(new Vector4f(0.5F, 0F, 1F, 0F), new GuiPadding(4, 52, 0, -64), 0), "/1 (100%)")
+                .setColor(PresetColor.TEXT_MAIN.getColor());
         cvRight.addPanel(textWeight);
-        
+
         final GuiScreen screenRef = this;
-        cvRight.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_EDGE, new GuiPadding(0, -16, 0, 0), 0), -1, QuestTranslation.translate("bq_standard.btn.add_remove_drops"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                if(selGroup != null)
-                {
-                    SendChanges();
-                    mc.displayGuiScreen(new GuiEditLootEntry(screenRef, selGroup));
-                }
-            }
-        });
-        
+        cvRight.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_EDGE, new GuiPadding(0, -16, 0, 0), 0),
+                        -1,
+                        QuestTranslation.translate("bq_standard.btn.add_remove_drops")) {
+                    @Override
+                    public void onButtonClick() {
+                        if (selGroup != null) {
+                            SendChanges();
+                            mc.displayGuiScreen(new GuiEditLootEntry(screenRef, selGroup));
+                        }
+                    }
+                });
+
         // === MISC ===
-        
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0), -1, QuestTranslation.translate("gui.done"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                SendChanges();
-                mc.displayGuiScreen(parent);
-            }
-        });
-        
+
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("gui.done")) {
+                    @Override
+                    public void onButtonClick() {
+                        SendChanges();
+                        mc.displayGuiScreen(parent);
+                    }
+                });
+
         // === DIVIDERS ===
-        
-		IGuiRect ls0 = new GuiTransform(GuiAlign.TOP_CENTER, 0, 32, 0, 0, 0);
-		ls0.setParent(cvBackground.getTransform());
-		IGuiRect le0 = new GuiTransform(GuiAlign.BOTTOM_CENTER, 0, -24, 0, 0, 0);
-		le0.setParent(cvBackground.getTransform());
-		PanelLine paLine0 = new PanelLine(ls0, le0, PresetLine.GUI_DIVIDER.getLine(), 1, PresetColor.GUI_DIVIDER.getColor(), 1);
-		cvBackground.addPanel(paLine0);
-        
+
+        IGuiRect ls0 = new GuiTransform(GuiAlign.TOP_CENTER, 0, 32, 0, 0, 0);
+        ls0.setParent(cvBackground.getTransform());
+        IGuiRect le0 = new GuiTransform(GuiAlign.BOTTOM_CENTER, 0, -24, 0, 0, 0);
+        le0.setParent(cvBackground.getTransform());
+        PanelLine paLine0 =
+                new PanelLine(ls0, le0, PresetLine.GUI_DIVIDER.getLine(), 1, PresetColor.GUI_DIVIDER.getColor(), 1);
+        cvBackground.addPanel(paLine0);
+
         refreshGroups();
     }
-    
+
     @Override
-    public void drawPanel(int mx, int my, float partialTick)
-    {
+    public void drawPanel(int mx, int my, float partialTick) {
         // TODO: Another horrible workaround that needs replacing
-        if(LootRegistry.INSTANCE.updateUI)
-        {
+        if (LootRegistry.INSTANCE.updateUI) {
             LootRegistry.INSTANCE.updateUI = false;
-            
-            if(selectedID >= 0)
-            {
+
+            if (selectedID >= 0) {
                 selGroup = LootRegistry.INSTANCE.getValue(selectedID);
-                
-                if(selGroup == null)
-                {
+
+                if (selGroup == null) {
                     selectedID = -1;
-                    
+
                     fieldName.setText("");
                     fieldWeight.setText("1");
                     textWeight.setText("/1 (100%)");
-                } else
-                {
+                } else {
                     selGroup.name = fieldName.getValue();
                     selGroup.weight = fieldWeight.getValue();
-                    
+
                     int totalWeight = LootRegistry.INSTANCE.getTotalWeight();
-                    float chance = selGroup.weight / (float)totalWeight * 100F;
+                    float chance = selGroup.weight / (float) totalWeight * 100F;
                     textWeight.setText("/" + totalWeight + " (" + numFormat.format(chance) + "%)");
                 }
             }
-            
+
             refreshGroups();
         }
-        
+
         super.drawPanel(mx, my, partialTick);
     }
-    
-    private void refreshGroups()
-    {
+
+    private void refreshGroups() {
         lootList.resetCanvas();
         int lWidth = lootList.getTransform().getWidth();
         final List<DBEntry<LootGroup>> lgAry = LootRegistry.INSTANCE.getEntries();
-        
-        for(int i = 0; i < lgAry.size(); i++)
-        {
-            lootList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 16, 16, 0), -1, "", lgAry.get(i)).setCallback(value ->
-            {
-                LootRegistry.INSTANCE.removeID(value.getID());
-                refreshGroups();
-                SendChanges();
-            }).setIcon(PresetIcon.ICON_TRASH.getTexture()));
-            
-            lootList.addPanel(new PanelButtonStorage<>(new GuiRectangle(16, i * 16, lWidth - 16, 16, 0), -1, lgAry.get(i).getValue().name, lgAry.get(i)).setCallback(value ->
-            {
-                if(selGroup != null) SendChanges();
-                selectedID = value.getID();
-                selGroup = value.getValue();
-                fieldName.setText(selGroup.name);
-                fieldWeight.setText("" + selGroup.weight);
-                
-                int totalWeight = LootRegistry.INSTANCE.getTotalWeight();
-                float chance = selGroup.weight / (float)totalWeight * 100F;
-                textWeight.setText("/" + totalWeight + " (" + numFormat.format(chance) + "%)");
-            }));
+
+        for (int i = 0; i < lgAry.size(); i++) {
+            lootList.addPanel(new PanelButtonStorage<>(new GuiRectangle(0, i * 16, 16, 16, 0), -1, "", lgAry.get(i))
+                    .setCallback(value -> {
+                        LootRegistry.INSTANCE.removeID(value.getID());
+                        refreshGroups();
+                        SendChanges();
+                    })
+                    .setIcon(PresetIcon.ICON_TRASH.getTexture()));
+
+            lootList.addPanel(new PanelButtonStorage<>(
+                            new GuiRectangle(16, i * 16, lWidth - 16, 16, 0),
+                            -1,
+                            lgAry.get(i).getValue().name,
+                            lgAry.get(i))
+                    .setCallback(value -> {
+                        if (selGroup != null) SendChanges();
+                        selectedID = value.getID();
+                        selGroup = value.getValue();
+                        fieldName.setText(selGroup.name);
+                        fieldWeight.setText("" + selGroup.weight);
+
+                        int totalWeight = LootRegistry.INSTANCE.getTotalWeight();
+                        float chance = selGroup.weight / (float) totalWeight * 100F;
+                        textWeight.setText("/" + totalWeight + " (" + numFormat.format(chance) + "%)");
+                    }));
         }
     }
-	
-	private void SendChanges()
-	{
+
+    private void SendChanges() {
         NetLootImport.importLoot(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
-	}
+    }
 }

--- a/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskHunt.java
+++ b/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskHunt.java
@@ -33,93 +33,122 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.input.Keyboard;
 
-public class GuiEditTaskHunt extends GuiScreenCanvas
-{
+public class GuiEditTaskHunt extends GuiScreenCanvas {
     private final DBEntry<IQuest> quest;
     private final TaskHunt task;
-    
-    public GuiEditTaskHunt(GuiScreen parent, DBEntry<IQuest> quest, TaskHunt task)
-    {
+
+    public GuiEditTaskHunt(GuiScreen parent, DBEntry<IQuest> quest, TaskHunt task) {
         super(parent);
         this.quest = quest;
         this.task = task;
         this.setVolatile(true);
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-        
+
         Keyboard.enableRepeatEvents(true);
-        
+
         CanvasTextured cvBackground = new CanvasTextured(new GuiTransform(), PresetTexture.PANEL_MAIN.getTexture());
         this.addPanel(cvBackground);
-        
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0), QuestTranslation.translate("bq_standard.title.edit_hunt")).setAlignment(1).setColor(PresetColor.TEXT_HEADER.getColor()));
-        
+
+        cvBackground.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0),
+                        QuestTranslation.translate("bq_standard.title.edit_hunt"))
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_HEADER.getColor()));
+
         final Entity target;
-        
-        if(EntityList.stringToClassMapping.containsKey(task.idName))
-        {
+
+        if (EntityList.stringToClassMapping.containsKey(task.idName)) {
             target = EntityList.createEntityByName(task.idName, Minecraft.getMinecraft().theWorld);
-            if(target != null) target.readFromNBT(task.targetTags);
+            if (target != null) target.readFromNBT(task.targetTags);
         } else target = null;
-        
-        this.addPanel(new PanelEntityPreview(new GuiTransform(GuiAlign.HALF_TOP, new GuiPadding(16, 32, 16, 0), 0), target).setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() -> (float)(Minecraft.getSystemTime()%30000L / 30000D * 360D)))); // Preview works with null. It's fine (or should be)
-        
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.MID_CENTER, -100, 4, 96, 12, 0), QuestTranslation.translate("bq_standard.gui.amount")).setAlignment(2).setColor(PresetColor.TEXT_MAIN.getColor()));
-        cvBackground.addPanel( new PanelTextField<>(new GuiTransform(GuiAlign.MID_CENTER, 0, 0, 100, 16, 0), "" + task.required, FieldFilterNumber.INT).setCallback(value -> task.required = value));
-        
+
+        this.addPanel(
+                new PanelEntityPreview(new GuiTransform(GuiAlign.HALF_TOP, new GuiPadding(16, 32, 16, 0), 0), target)
+                        .setRotationDriven(
+                                new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() -> (float) (Minecraft.getSystemTime()
+                                        % 30000L
+                                        / 30000D
+                                        * 360D)))); // Preview works with null. It's fine (or should be)
+
+        cvBackground.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, 4, 96, 12, 0),
+                        QuestTranslation.translate("bq_standard.gui.amount"))
+                .setAlignment(2)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+        cvBackground.addPanel(new PanelTextField<>(
+                        new GuiTransform(GuiAlign.MID_CENTER, 0, 0, 100, 16, 0),
+                        "" + task.required,
+                        FieldFilterNumber.INT)
+                .setCallback(value -> task.required = value));
+
         final GuiScreen screenRef = this;
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 16, 200, 16, 0), -1, QuestTranslation.translate("bq_standard.btn.select_mob"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_ENTITY, new GArgsCallback<>(screenRef, target, value -> {
-                    Entity tmp = value != null ? value : new EntityZombie(mc.theWorld);
-                    String res = EntityList.getEntityString(tmp);
-                    task.idName = res != null ? res : "Zombie";
-                    task.targetTags = new NBTTagCompound();
-                    tmp.writeToNBTOptional(task.targetTags);
-                    
-                    sendChanges();
-                })));
-            }
-        });
-        
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
-            }
-        });
-        
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0), -1, QuestTranslation.translate("gui.done"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                sendChanges();
-                mc.displayGuiScreen(parent);
-            }
-        });
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, 16, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("bq_standard.btn.select_mob")) {
+                    @Override
+                    public void onButtonClick() {
+                        mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                                .getGui(PresetGUIs.EDIT_ENTITY, new GArgsCallback<>(screenRef, target, value -> {
+                                    Entity tmp = value != null ? value : new EntityZombie(mc.theWorld);
+                                    String res = EntityList.getEntityString(tmp);
+                                    task.idName = res != null ? res : "Zombie";
+                                    task.targetTags = new NBTTagCompound();
+                                    tmp.writeToNBTOptional(task.targetTags);
+
+                                    sendChanges();
+                                })));
+                    }
+                });
+
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("betterquesting.btn.advanced")) {
+                    @Override
+                    public void onButtonClick() {
+                        mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                                .getGui(
+                                        PresetGUIs.EDIT_NBT,
+                                        new GArgsNBT<>(
+                                                screenRef,
+                                                task.writeToNBT(new NBTTagCompound()),
+                                                task::readFromNBT,
+                                                null)));
+                    }
+                });
+
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("gui.done")) {
+                    @Override
+                    public void onButtonClick() {
+                        sendChanges();
+                        mc.displayGuiScreen(parent);
+                    }
+                });
     }
-    
-    private static final ResourceLocation QUEST_EDIT = new ResourceLocation("betterquesting:quest_edit"); // TODO: Really need to make the native packet types accessible in the API
-    private void sendChanges()
-    {
-		NBTTagCompound payload = new NBTTagCompound();
+
+    private static final ResourceLocation QUEST_EDIT = new ResourceLocation(
+            "betterquesting:quest_edit"); // TODO: Really need to make the native packet types accessible in the API
+
+    private void sendChanges() {
+        NBTTagCompound payload = new NBTTagCompound();
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-		entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
-		dataList.appendTag(entry);
-		payload.setTag("data", dataList);
-		payload.setInteger("action", 0); // Action: Update data
-		QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(QUEST_EDIT, payload));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        dataList.appendTag(entry);
+        payload.setTag("data", dataList);
+        payload.setInteger("action", 0); // Action: Update data
+        QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(QUEST_EDIT, payload));
     }
 }

--- a/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskMeeting.java
+++ b/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskMeeting.java
@@ -33,91 +33,120 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.input.Keyboard;
 
-public class GuiEditTaskMeeting extends GuiScreenCanvas
-{
+public class GuiEditTaskMeeting extends GuiScreenCanvas {
     private final DBEntry<IQuest> quest;
     private final TaskMeeting task;
-    
-    public GuiEditTaskMeeting(GuiScreen parent, DBEntry<IQuest> quest, TaskMeeting task)
-    {
+
+    public GuiEditTaskMeeting(GuiScreen parent, DBEntry<IQuest> quest, TaskMeeting task) {
         super(parent);
         this.quest = quest;
         this.task = task;
         this.setVolatile(true);
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-        
+
         Keyboard.enableRepeatEvents(true);
-        
+
         CanvasTextured cvBackground = new CanvasTextured(new GuiTransform(), PresetTexture.PANEL_MAIN.getTexture());
         this.addPanel(cvBackground);
-        
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0), QuestTranslation.translate("bq_standard.title.edit_meeting")).setAlignment(1).setColor(PresetColor.TEXT_HEADER.getColor()));
-        
+
+        cvBackground.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0),
+                        QuestTranslation.translate("bq_standard.title.edit_meeting"))
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_HEADER.getColor()));
+
         final Entity target;
-        
-        if(EntityList.stringToClassMapping.containsKey(task.idName))
-        {
+
+        if (EntityList.stringToClassMapping.containsKey(task.idName)) {
             target = EntityList.createEntityByName(task.idName, Minecraft.getMinecraft().theWorld);
-            if(target != null) target.readFromNBT(task.targetTags);
+            if (target != null) target.readFromNBT(task.targetTags);
         } else target = null;
-        
-        this.addPanel(new PanelEntityPreview(new GuiTransform(GuiAlign.HALF_TOP, new GuiPadding(16, 32, 16, 0), 0), target).setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() -> (float)(Minecraft.getSystemTime()%30000L / 30000D * 360D)))); // Preview works with null. It's fine (or should be)
-        
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.MID_CENTER, -100, 4, 96, 12, 0), QuestTranslation.translate("bq_standard.gui.amount")).setAlignment(2).setColor(PresetColor.TEXT_MAIN.getColor()));
-        cvBackground.addPanel(new PanelTextField<>(new GuiTransform(GuiAlign.MID_CENTER, 0, 0, 100, 16, 0), "" + task.amount, FieldFilterNumber.INT).setCallback(value -> task.amount = value));
-        
+
+        this.addPanel(
+                new PanelEntityPreview(new GuiTransform(GuiAlign.HALF_TOP, new GuiPadding(16, 32, 16, 0), 0), target)
+                        .setRotationDriven(
+                                new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() -> (float) (Minecraft.getSystemTime()
+                                        % 30000L
+                                        / 30000D
+                                        * 360D)))); // Preview works with null. It's fine (or should be)
+
+        cvBackground.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, 4, 96, 12, 0),
+                        QuestTranslation.translate("bq_standard.gui.amount"))
+                .setAlignment(2)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+        cvBackground.addPanel(new PanelTextField<>(
+                        new GuiTransform(GuiAlign.MID_CENTER, 0, 0, 100, 16, 0),
+                        "" + task.amount,
+                        FieldFilterNumber.INT)
+                .setCallback(value -> task.amount = value));
+
         final GuiScreen screenRef = this;
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 16, 200, 16, 0), -1, QuestTranslation.translate("bq_standard.btn.select_mob"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_ENTITY, new GArgsCallback<>(screenRef, target, value -> {
-                    Entity tmp = value != null ? value : new EntityVillager(mc.theWorld);
-                    String res = EntityList.getEntityString(tmp);
-                    task.idName = res != null ? res : "Villager";
-                    task.targetTags = new NBTTagCompound();
-                    tmp.writeToNBTOptional(task.targetTags);
-                })));
-            }
-        });
-        
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
-            }
-        });
-        
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0), -1, QuestTranslation.translate("gui.back"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                sendChanges();
-                mc.displayGuiScreen(parent);
-            }
-        });
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, 16, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("bq_standard.btn.select_mob")) {
+                    @Override
+                    public void onButtonClick() {
+                        mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                                .getGui(PresetGUIs.EDIT_ENTITY, new GArgsCallback<>(screenRef, target, value -> {
+                                    Entity tmp = value != null ? value : new EntityVillager(mc.theWorld);
+                                    String res = EntityList.getEntityString(tmp);
+                                    task.idName = res != null ? res : "Villager";
+                                    task.targetTags = new NBTTagCompound();
+                                    tmp.writeToNBTOptional(task.targetTags);
+                                })));
+                    }
+                });
+
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, 32, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("betterquesting.btn.advanced")) {
+                    @Override
+                    public void onButtonClick() {
+                        mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                                .getGui(
+                                        PresetGUIs.EDIT_NBT,
+                                        new GArgsNBT<>(
+                                                screenRef,
+                                                task.writeToNBT(new NBTTagCompound()),
+                                                task::readFromNBT,
+                                                null)));
+                    }
+                });
+
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("gui.back")) {
+                    @Override
+                    public void onButtonClick() {
+                        sendChanges();
+                        mc.displayGuiScreen(parent);
+                    }
+                });
     }
-    
-    private static final ResourceLocation QUEST_EDIT = new ResourceLocation("betterquesting:quest_edit"); // TODO: Really need to make the native packet types accessible in the API
-    private void sendChanges()
-    {
-		NBTTagCompound payload = new NBTTagCompound();
+
+    private static final ResourceLocation QUEST_EDIT = new ResourceLocation(
+            "betterquesting:quest_edit"); // TODO: Really need to make the native packet types accessible in the API
+
+    private void sendChanges() {
+        NBTTagCompound payload = new NBTTagCompound();
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-		entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
-		dataList.appendTag(entry);
-		payload.setTag("data", dataList);
-		payload.setInteger("action", 0); // Action: Update data
-		QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(QUEST_EDIT, payload));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        dataList.appendTag(entry);
+        payload.setTag("data", dataList);
+        payload.setInteger("action", 0); // Action: Update data
+        QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(QUEST_EDIT, payload));
     }
 }

--- a/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskScoreboard.java
+++ b/src/main/java/bq_standard/client/gui/editors/tasks/GuiEditTaskScoreboard.java
@@ -29,84 +29,116 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.input.Keyboard;
 
-public class GuiEditTaskScoreboard extends GuiScreenCanvas
-{
+public class GuiEditTaskScoreboard extends GuiScreenCanvas {
     private final DBEntry<IQuest> quest;
     private final TaskScoreboard task;
-    
-    public GuiEditTaskScoreboard(GuiScreen parent, DBEntry<IQuest> quest, TaskScoreboard task)
-    {
+
+    public GuiEditTaskScoreboard(GuiScreen parent, DBEntry<IQuest> quest, TaskScoreboard task) {
         super(parent);
         this.quest = quest;
         this.task = task;
         this.setVolatile(true);
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-        
+
         Keyboard.enableRepeatEvents(true);
-        
+
         CanvasTextured cvBackground = new CanvasTextured(new GuiTransform(), PresetTexture.PANEL_MAIN.getTexture());
         this.addPanel(cvBackground);
-        
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0), QuestTranslation.translate("bq_standard.title.edit_scoreboard")).setAlignment(1).setColor(PresetColor.TEXT_HEADER.getColor()));
-        
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.MID_CENTER, -100, -28, 50, 12, 0), QuestTranslation.translate("betterquesting.gui.name")).setColor(PresetColor.TEXT_MAIN.getColor()));
-        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.MID_CENTER, -100, -12, 50, 12, 0), "ID").setColor(PresetColor.TEXT_MAIN.getColor())); // TODO: Localise this?
-        
-        cvBackground.addPanel(new PanelTextField<>(new GuiTransform(GuiAlign.MID_CENTER, -50, -32, 150, 16, 0), task.scoreDisp, FieldFilterString.INSTANCE).setCallback(value -> task.scoreDisp = value));
-        cvBackground.addPanel(new PanelTextField<>(new GuiTransform(GuiAlign.MID_CENTER, -50, -16, 150, 16, 0), task.scoreName, FieldFilterString.INSTANCE).setCallback(value -> task.scoreName = value));
-        
-        cvBackground.addPanel(new PanelButtonStorage<ScoreOperation>(new GuiTransform(GuiAlign.MID_CENTER, -100, 0, 50, 16, 0), -1, task.operation.GetText(), task.operation)
-        {
-            @Override
-            public void onButtonClick()
-            {
-                ScoreOperation[] v = ScoreOperation.values();
-                ScoreOperation n = v[(getStoredValue().ordinal() + 1)%v.length];
-                this.setStoredValue(n);
-                this.setText(n.GetText());
-                task.operation = n;
-            }
-        });
-        
-        cvBackground.addPanel(new PanelTextField<>(new GuiTransform(GuiAlign.MID_CENTER, -50, 0, 150, 16, 0), "" + task.target, FieldFilterNumber.INT).setCallback(value -> task.target = value));
-        
+
+        cvBackground.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, new GuiPadding(16, 16, 16, -32), 0),
+                        QuestTranslation.translate("bq_standard.title.edit_scoreboard"))
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_HEADER.getColor()));
+
+        cvBackground.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, -28, 50, 12, 0),
+                        QuestTranslation.translate("betterquesting.gui.name"))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+        cvBackground.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.MID_CENTER, -100, -12, 50, 12, 0), "ID")
+                .setColor(PresetColor.TEXT_MAIN.getColor())); // TODO: Localise this?
+
+        cvBackground.addPanel(new PanelTextField<>(
+                        new GuiTransform(GuiAlign.MID_CENTER, -50, -32, 150, 16, 0),
+                        task.scoreDisp,
+                        FieldFilterString.INSTANCE)
+                .setCallback(value -> task.scoreDisp = value));
+        cvBackground.addPanel(new PanelTextField<>(
+                        new GuiTransform(GuiAlign.MID_CENTER, -50, -16, 150, 16, 0),
+                        task.scoreName,
+                        FieldFilterString.INSTANCE)
+                .setCallback(value -> task.scoreName = value));
+
+        cvBackground.addPanel(
+                new PanelButtonStorage<ScoreOperation>(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, 0, 50, 16, 0),
+                        -1,
+                        task.operation.GetText(),
+                        task.operation) {
+                    @Override
+                    public void onButtonClick() {
+                        ScoreOperation[] v = ScoreOperation.values();
+                        ScoreOperation n = v[(getStoredValue().ordinal() + 1) % v.length];
+                        this.setStoredValue(n);
+                        this.setText(n.GetText());
+                        task.operation = n;
+                    }
+                });
+
+        cvBackground.addPanel(new PanelTextField<>(
+                        new GuiTransform(GuiAlign.MID_CENTER, -50, 0, 150, 16, 0),
+                        "" + task.target,
+                        FieldFilterNumber.INT)
+                .setCallback(value -> task.target = value));
+
         final GuiScreen screenRef = this;
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.MID_CENTER, -100, 16, 200, 16, 0), -1, QuestTranslation.translate("betterquesting.btn.advanced"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG).getGui(PresetGUIs.EDIT_NBT, new GArgsNBT<>(screenRef, task.writeToNBT(new NBTTagCompound()), task::readFromNBT, null)));
-            }
-        });
-        
-        cvBackground.addPanel(new PanelButton(new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0), -1, QuestTranslation.translate("gui.back"))
-        {
-            @Override
-            public void onButtonClick()
-            {
-                sendChanges();
-                mc.displayGuiScreen(parent);
-            }
-        });
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.MID_CENTER, -100, 16, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("betterquesting.btn.advanced")) {
+                    @Override
+                    public void onButtonClick() {
+                        mc.displayGuiScreen(QuestingAPI.getAPI(ApiReference.THEME_REG)
+                                .getGui(
+                                        PresetGUIs.EDIT_NBT,
+                                        new GArgsNBT<>(
+                                                screenRef,
+                                                task.writeToNBT(new NBTTagCompound()),
+                                                task::readFromNBT,
+                                                null)));
+                    }
+                });
+
+        cvBackground.addPanel(
+                new PanelButton(
+                        new GuiTransform(GuiAlign.BOTTOM_CENTER, -100, -16, 200, 16, 0),
+                        -1,
+                        QuestTranslation.translate("gui.back")) {
+                    @Override
+                    public void onButtonClick() {
+                        sendChanges();
+                        mc.displayGuiScreen(parent);
+                    }
+                });
     }
-    
-    private static final ResourceLocation QUEST_EDIT = new ResourceLocation("betterquesting:quest_edit"); // TODO: Really need to make the native packet types accessible in the API
-    private void sendChanges()
-    {
-		NBTTagCompound payload = new NBTTagCompound();
+
+    private static final ResourceLocation QUEST_EDIT = new ResourceLocation(
+            "betterquesting:quest_edit"); // TODO: Really need to make the native packet types accessible in the API
+
+    private void sendChanges() {
+        NBTTagCompound payload = new NBTTagCompound();
         NBTTagList dataList = new NBTTagList();
         NBTTagCompound entry = new NBTTagCompound();
         entry.setInteger("questID", quest.getID());
-		entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
-		dataList.appendTag(entry);
-		payload.setTag("data", dataList);
-		payload.setInteger("action", 0); // Action: Update data
-		QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(QUEST_EDIT, payload));
+        entry.setTag("config", quest.getValue().writeToNBT(new NBTTagCompound()));
+        dataList.appendTag(entry);
+        payload.setTag("data", dataList);
+        payload.setInteger("action", 0); // Action: Update data
+        QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(QUEST_EDIT, payload));
     }
 }

--- a/src/main/java/bq_standard/client/gui/panels/content/PanelItemSlotBuilder.java
+++ b/src/main/java/bq_standard/client/gui/panels/content/PanelItemSlotBuilder.java
@@ -14,8 +14,7 @@ public final class PanelItemSlotBuilder {
     private boolean showCount, oreDict;
 
     @SuppressWarnings("unused")
-    PanelItemSlotBuilder() {
-    }
+    PanelItemSlotBuilder() {}
 
     private PanelItemSlotBuilder(BigItemStack value, IGuiRect rectangle) {
         this.value = value;
@@ -45,7 +44,8 @@ public final class PanelItemSlotBuilder {
 
     public PanelItemSlot build() {
         PanelItemSlot slot;
-        if (BQ_Standard.hasNEI && value != null) slot = new PanelInteractiveItemSlot(rectangle, id, value, showCount, oreDict);
+        if (BQ_Standard.hasNEI && value != null)
+            slot = new PanelInteractiveItemSlot(rectangle, id, value, showCount, oreDict);
         else slot = new PanelItemSlot(rectangle, id, value, showCount, oreDict);
 
         return slot;

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardChoice.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardChoice.java
@@ -12,52 +12,51 @@ import betterquesting.api2.storage.DBEntry;
 import bq_standard.client.gui.panels.content.PanelItemSlotBuilder;
 import bq_standard.network.handlers.NetRewardChoice;
 import bq_standard.rewards.RewardChoice;
+import java.util.UUID;
 import net.minecraft.client.Minecraft;
 import org.lwjgl.util.vector.Vector4f;
 
-import java.util.UUID;
-
-public class PanelRewardChoice extends CanvasMinimum
-{
+public class PanelRewardChoice extends CanvasMinimum {
     private final DBEntry<IQuest> quest;
     private final RewardChoice reward;
     private final IGuiRect initialRect;
 
-    public PanelRewardChoice(IGuiRect rect, DBEntry<IQuest> quest, RewardChoice reward)
-    {
+    public PanelRewardChoice(IGuiRect rect, DBEntry<IQuest> quest, RewardChoice reward) {
         super(rect);
         initialRect = rect;
         this.quest = quest;
         this.reward = reward;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
 
         UUID uuid = QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer);
         int sel = reward.getSelecton(uuid);
 
         GuiTransform guiTransform = new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 0, 0, 32, 32, 0);
-        PanelItemSlot slot = PanelItemSlotBuilder.forValue(sel < 0 ? null : reward.choices.get(sel), guiTransform).build();
+        PanelItemSlot slot = PanelItemSlotBuilder.forValue(sel < 0 ? null : reward.choices.get(sel), guiTransform)
+                .build();
         this.addPanel(slot);
 
         final int qID = quest.getID();
         final int rID = quest.getValue().getRewards().getID(reward);
 
         int listWidth = initialRect.getWidth();
-        for(int i = 0; i < reward.choices.size(); i++)
-        {
+        for (int i = 0; i < reward.choices.size(); i++) {
             BigItemStack stack = reward.choices.get(i);
             GuiRectangle guiRectangle = new GuiRectangle(40, i * 18, 18, 18, 0);
             PanelItemSlot is = PanelItemSlotBuilder.forValue(stack, guiRectangle)
                     .showCount(true)
                     .build();
             this.addPanel(is);
-            
-            this.addPanel(new PanelTextBox(new GuiRectangle(62, i * 18 + 4, listWidth - 22, 14, 0), stack.stackSize + " " + stack.getBaseStack().getDisplayName()).setColor(PresetColor.TEXT_MAIN.getColor()));
-            
+
+            this.addPanel(new PanelTextBox(
+                            new GuiRectangle(62, i * 18 + 4, listWidth - 22, 14, 0),
+                            stack.stackSize + " " + stack.getBaseStack().getDisplayName())
+                    .setColor(PresetColor.TEXT_MAIN.getColor()));
+
             final int sID = i;
             is.setCallback(value -> NetRewardChoice.requestChoice(qID, rID, sID));
         }

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardCommand.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardCommand.java
@@ -1,10 +1,8 @@
 package bq_standard.client.gui.rewards;
 
 import betterquesting.api.utils.BigItemStack;
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelGeneric;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
@@ -15,27 +13,28 @@ import bq_standard.rewards.RewardCommand;
 import net.minecraft.init.Blocks;
 import org.lwjgl.util.vector.Vector4f;
 
-public class PanelRewardCommand extends CanvasMinimum
-{
+public class PanelRewardCommand extends CanvasMinimum {
     private final RewardCommand reward;
     private final IGuiRect initialRect;
-    
-    public PanelRewardCommand(IGuiRect rect, RewardCommand reward)
-    {
+
+    public PanelRewardCommand(IGuiRect rect, RewardCommand reward) {
         super(rect);
         this.reward = reward;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
-        this.addPanel(new PanelGeneric(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 0, 0, 32, 32, 0), new ItemTexture(new BigItemStack(Blocks.command_block))));
-        String txt = QuestTranslation.translate("advMode.command") + "\n" + (reward.hideCmd ? "[HIDDEN]" : reward.command);
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 0, 0, 32, 32, 0),
+                new ItemTexture(new BigItemStack(Blocks.command_block))));
+        String txt =
+                QuestTranslation.translate("advMode.command") + "\n" + (reward.hideCmd ? "[HIDDEN]" : reward.command);
         // TODO: Fix full text display by implementing normal measurement of the minimum required text height
-        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 40, 0, width - 40, 32, 0), txt).setColor(PresetColor.TEXT_MAIN.getColor()));
+        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 40, 0, width - 40, 32, 0), txt)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardItem.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardItem.java
@@ -9,26 +9,22 @@ import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import bq_standard.client.gui.panels.content.PanelItemSlotBuilder;
 import bq_standard.rewards.RewardItem;
 
-public class PanelRewardItem extends CanvasMinimum
-{
+public class PanelRewardItem extends CanvasMinimum {
     private final RewardItem reward;
     private final IGuiRect initialRect;
 
-    public PanelRewardItem(IGuiRect rect, RewardItem reward)
-    {
+    public PanelRewardItem(IGuiRect rect, RewardItem reward) {
         super(rect);
         this.reward = reward;
         initialRect = rect;
     }
 
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
 
         int listWidth = initialRect.getWidth();
-        for(int i = 0; i < reward.items.size(); i++)
-        {
+        for (int i = 0; i < reward.items.size(); i++) {
             BigItemStack stack = reward.items.get(i);
             GuiRectangle rectangle = new GuiRectangle(0, i * 18, 18, 18, 0);
             PanelItemSlot is = PanelItemSlotBuilder.forValue(stack, rectangle)
@@ -36,7 +32,10 @@ public class PanelRewardItem extends CanvasMinimum
                     .build();
             this.addPanel(is);
 
-            this.addPanel(new PanelTextBox(new GuiRectangle(22, i * 18 + 4, listWidth - 22, 14, 0), stack.stackSize + " " + stack.getBaseStack().getDisplayName()).setColor(PresetColor.TEXT_MAIN.getColor()));
+            this.addPanel(new PanelTextBox(
+                            new GuiRectangle(22, i * 18 + 4, listWidth - 22, 14, 0),
+                            stack.stackSize + " " + stack.getBaseStack().getDisplayName())
+                    .setColor(PresetColor.TEXT_MAIN.getColor()));
         }
 
         recalcSizes();

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardQuestCompletion.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardQuestCompletion.java
@@ -1,7 +1,5 @@
 package bq_standard.client.gui.rewards;
 
-import org.lwjgl.util.vector.Vector4f;
-
 import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
@@ -15,25 +13,33 @@ import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.QuestTranslation;
 import bq_standard.rewards.RewardQuestCompletion;
+import org.lwjgl.util.vector.Vector4f;
 
 public class PanelRewardQuestCompletion extends CanvasMinimum {
-	private final RewardQuestCompletion reward;
+    private final RewardQuestCompletion reward;
     private final IGuiRect initialRect;
-    
+
     public PanelRewardQuestCompletion(IGuiRect rect, RewardQuestCompletion reward) {
         super(rect);
         this.reward = reward;
         initialRect = rect;
     }
-    
+
     @Override
     public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
 
         IQuest quest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(reward.questNum);
-        this.addPanel(new PanelButtonQuest(new GuiRectangle(0, 0, 18, 18, 0), -1, "", quest == null ? null : new DBEntry<>(reward.questNum, quest)));
-        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 36, 2, width - 36, 16, 0), QuestTranslation.translate("bq_standard.gui.questcompletion")).setColor(PresetColor.TEXT_MAIN.getColor()));
+        this.addPanel(new PanelButtonQuest(
+                new GuiRectangle(0, 0, 18, 18, 0),
+                -1,
+                "",
+                quest == null ? null : new DBEntry<>(reward.questNum, quest)));
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 36, 2, width - 36, 16, 0),
+                        QuestTranslation.translate("bq_standard.gui.questcompletion"))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardScoreboard.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardScoreboard.java
@@ -1,9 +1,7 @@
 package bq_standard.client.gui.rewards;
 
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
@@ -11,38 +9,34 @@ import bq_standard.rewards.RewardScoreboard;
 import net.minecraft.util.EnumChatFormatting;
 import org.lwjgl.util.vector.Vector4f;
 
-public class PanelRewardScoreboard extends CanvasMinimum
-{
+public class PanelRewardScoreboard extends CanvasMinimum {
     private final RewardScoreboard reward;
     private final IGuiRect initialRect;
-    
-    public PanelRewardScoreboard(IGuiRect rect, RewardScoreboard reward)
-    {
+
+    public PanelRewardScoreboard(IGuiRect rect, RewardScoreboard reward) {
         super(rect);
         this.reward = reward;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
-        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 0, 0, width, 12, 0), reward.score).setColor(PresetColor.TEXT_MAIN.getColor()));
-		String txt2 = EnumChatFormatting.BOLD.toString();
-		
-		if(!reward.relative)
-		{
-			txt2 += "= " + reward.value;
-		} else if(reward.value >= 0)
-		{
-			txt2 += EnumChatFormatting.GREEN + "+ " + Math.abs(reward.value);
-		} else
-		{
-			txt2 += EnumChatFormatting.RED + "- " + Math.abs(reward.value);
-		}
-		
-        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 4, 12, width - 4, 12, 0), txt2).setColor(PresetColor.TEXT_MAIN.getColor()));
+        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 0, 0, width, 12, 0), reward.score)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+        String txt2 = EnumChatFormatting.BOLD.toString();
+
+        if (!reward.relative) {
+            txt2 += "= " + reward.value;
+        } else if (reward.value >= 0) {
+            txt2 += EnumChatFormatting.GREEN + "+ " + Math.abs(reward.value);
+        } else {
+            txt2 += EnumChatFormatting.RED + "- " + Math.abs(reward.value);
+        }
+
+        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 4, 12, width - 4, 12, 0), txt2)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/rewards/PanelRewardXP.java
+++ b/src/main/java/bq_standard/client/gui/rewards/PanelRewardXP.java
@@ -1,10 +1,8 @@
 package bq_standard.client.gui.rewards;
 
 import betterquesting.api.utils.BigItemStack;
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelGeneric;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
@@ -16,39 +14,40 @@ import net.minecraft.init.Items;
 import net.minecraft.util.EnumChatFormatting;
 import org.lwjgl.util.vector.Vector4f;
 
-public class PanelRewardXP extends CanvasMinimum
-{
+public class PanelRewardXP extends CanvasMinimum {
     private final RewardXP reward;
     private final IGuiRect initialRect;
-    
-    public PanelRewardXP(IGuiRect rect, RewardXP reward)
-    {
+
+    public PanelRewardXP(IGuiRect rect, RewardXP reward) {
         super(rect);
         this.reward = reward;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
-        this.addPanel(new PanelGeneric(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 0, 0, 32, 32, 0), new ItemTexture(new BigItemStack(Items.experience_bottle))));
-        
-		String txt2;
-		
-		if(reward.amount >= 0)
-		{
-			txt2 = EnumChatFormatting.GREEN + "+" + Math.abs(reward.amount);
-		} else
-		{
-			txt2 = EnumChatFormatting.RED + "-" + Math.abs(reward.amount);
-		}
-		
-		txt2 += reward.levels? "L" : "XP";
-		
-        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 36, 2, width - 36, 16, 0), QuestTranslation.translate("bq_standard.gui.experience")).setColor(PresetColor.TEXT_MAIN.getColor()));
-        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 40, 16, width - 40, 16, 0), txt2).setColor(PresetColor.TEXT_MAIN.getColor()));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 0, 0, 32, 32, 0),
+                new ItemTexture(new BigItemStack(Items.experience_bottle))));
+
+        String txt2;
+
+        if (reward.amount >= 0) {
+            txt2 = EnumChatFormatting.GREEN + "+" + Math.abs(reward.amount);
+        } else {
+            txt2 = EnumChatFormatting.RED + "-" + Math.abs(reward.amount);
+        }
+
+        txt2 += reward.levels ? "L" : "XP";
+
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 36, 2, width - 36, 16, 0),
+                        QuestTranslation.translate("bq_standard.gui.experience"))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+        this.addPanel(new PanelTextBox(new GuiTransform(new Vector4f(0F, 0F, 0F, 0F), 40, 16, width - 40, 16, 0), txt2)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskBlockBreak.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskBlockBreak.java
@@ -3,74 +3,69 @@ package bq_standard.client.gui.tasks;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api2.client.gui.misc.*;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
-import betterquesting.api2.client.gui.panels.bars.PanelVScrollBar;
 import betterquesting.api2.client.gui.panels.content.PanelItemSlot;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
-import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.utils.QuestTranslation;
 import bq_standard.tasks.TaskBlockBreak;
+import java.util.UUID;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.EnumChatFormatting;
 
-import java.util.UUID;
-
-public class PanelTaskBlockBreak extends CanvasMinimum
-{
+public class PanelTaskBlockBreak extends CanvasMinimum {
     private final TaskBlockBreak task;
     private final IGuiRect initialRect;
-    
-    public PanelTaskBlockBreak(IGuiRect rect, TaskBlockBreak task)
-    {
+
+    public PanelTaskBlockBreak(IGuiRect rect, TaskBlockBreak task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-        
+
         UUID uuid = QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer);
         int[] progress = task.getUsersProgress(uuid);
         boolean isComplete = task.isComplete(uuid);
-        
+
         int listW = initialRect.getWidth();
-        
-        for(int i = 0; i < task.blockTypes.size(); i++)
-        {
+
+        for (int i = 0; i < task.blockTypes.size(); i++) {
             BigItemStack stack = task.blockTypes.get(i).getItemStack();
-            
-            if(stack == null)
-            {
+
+            if (stack == null) {
                 continue;
             }
-    
+
             PanelItemSlot slot = new PanelItemSlot(new GuiRectangle(0, i * 36, 36, 36, 0), -1, stack, true, true);
             this.addPanel(slot);
-            
+
             StringBuilder sb = new StringBuilder();
-            
+
             sb.append(stack.getBaseStack().getDisplayName());
-			
-			if(stack.hasOreDict()) sb.append(" (").append(stack.getOreDict()).append(")");
-			
-			sb.append("\n").append(progress[i]).append("/").append(stack.stackSize).append("\n");
-			
-			if(progress[i] >= stack.stackSize || isComplete)
-			{
-				sb.append(EnumChatFormatting.GREEN).append(QuestTranslation.translate("betterquesting.tooltip.complete"));
-			} else
-			{
-				sb.append(EnumChatFormatting.RED).append(QuestTranslation.translate("betterquesting.tooltip.incomplete"));
-			}
-            
+
+            if (stack.hasOreDict()) sb.append(" (").append(stack.getOreDict()).append(")");
+
+            sb.append("\n")
+                    .append(progress[i])
+                    .append("/")
+                    .append(stack.stackSize)
+                    .append("\n");
+
+            if (progress[i] >= stack.stackSize || isComplete) {
+                sb.append(EnumChatFormatting.GREEN)
+                        .append(QuestTranslation.translate("betterquesting.tooltip.complete"));
+            } else {
+                sb.append(EnumChatFormatting.RED)
+                        .append(QuestTranslation.translate("betterquesting.tooltip.incomplete"));
+            }
+
             PanelTextBox text = new PanelTextBox(new GuiRectangle(40, i * 36, listW - 40, 36, 0), sb.toString());
-			text.setColor(PresetColor.TEXT_MAIN.getColor());
-			this.addPanel(text);
+            text.setColor(PresetColor.TEXT_MAIN.getColor());
+            this.addPanel(text);
         }
 
         recalcSizes();

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskCheckbox.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskCheckbox.java
@@ -6,7 +6,6 @@ import betterquesting.api2.client.gui.controls.PanelButton;
 import betterquesting.api2.client.gui.misc.GuiAlign;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.resources.colors.GuiColorStatic;
 import betterquesting.api2.client.gui.themes.presets.PresetIcon;
@@ -15,42 +14,42 @@ import bq_standard.network.handlers.NetTaskCheckbox;
 import bq_standard.tasks.TaskCheckbox;
 import net.minecraft.client.Minecraft;
 
-public class PanelTaskCheckbox extends CanvasMinimum
-{
+public class PanelTaskCheckbox extends CanvasMinimum {
     private final DBEntry<IQuest> quest;
     private final TaskCheckbox task;
     private final IGuiRect initialRect;
 
-    public PanelTaskCheckbox(IGuiRect rect, DBEntry<IQuest> quest, TaskCheckbox task)
-    {
+    public PanelTaskCheckbox(IGuiRect rect, DBEntry<IQuest> quest, TaskCheckbox task) {
         super(rect);
         this.quest = quest;
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-        
+
         boolean isComplete = task.isComplete(QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer));
 
         final int questID = quest.getID();
         final int taskID = quest.getValue().getTasks().getID(task);
 
-        PanelButton btnCheck = new PanelButton(new GuiTransform(GuiAlign.TOP_LEFT, (initialRect.getWidth() - 32) / 2, 0, 32, 32, 0), -1, "")
-        {
-            @Override
-            public void onButtonClick()
-            {
-                setIcon(PresetIcon.ICON_TICK.getTexture(), new GuiColorStatic(0xFF00FF00), 4);
-                setActive(false);
+        PanelButton btnCheck =
+                new PanelButton(
+                        new GuiTransform(GuiAlign.TOP_LEFT, (initialRect.getWidth() - 32) / 2, 0, 32, 32, 0), -1, "") {
+                    @Override
+                    public void onButtonClick() {
+                        setIcon(PresetIcon.ICON_TICK.getTexture(), new GuiColorStatic(0xFF00FF00), 4);
+                        setActive(false);
 
-                NetTaskCheckbox.requestClick(questID, taskID);
-            }
-        };
-        btnCheck.setIcon(isComplete ? PresetIcon.ICON_TICK.getTexture() : PresetIcon.ICON_CROSS.getTexture(), new GuiColorStatic(isComplete ? 0xFF00FF00 : 0xFFFF0000), 4);
+                        NetTaskCheckbox.requestClick(questID, taskID);
+                    }
+                };
+        btnCheck.setIcon(
+                isComplete ? PresetIcon.ICON_TICK.getTexture() : PresetIcon.ICON_CROSS.getTexture(),
+                new GuiColorStatic(isComplete ? 0xFF00FF00 : 0xFFFF0000),
+                4);
         btnCheck.setActive(!isComplete);
         this.addPanel(btnCheck);
         recalcSizes();

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskCrafting.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskCrafting.java
@@ -15,31 +15,25 @@ import betterquesting.api2.client.gui.resources.textures.ItemTexture;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import betterquesting.api2.utils.QuestTranslation;
-import bq_standard.client.gui.panels.content.PanelInteractiveItemSlot;
 import bq_standard.client.gui.panels.content.PanelItemSlotBuilder;
-import bq_standard.core.BQ_Standard;
 import bq_standard.tasks.TaskCrafting;
+import java.util.UUID;
 import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumChatFormatting;
 
-import java.util.UUID;
-
-public class PanelTaskCrafting extends CanvasMinimum
-{
+public class PanelTaskCrafting extends CanvasMinimum {
     private final TaskCrafting task;
     private final IGuiRect initialRect;
 
-    public PanelTaskCrafting(IGuiRect rect, TaskCrafting task)
-    {
+    public PanelTaskCrafting(IGuiRect rect, TaskCrafting task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
 
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
 
         UUID uuid = QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer);
@@ -49,19 +43,21 @@ public class PanelTaskCrafting extends CanvasMinimum
         IGuiTexture txTick = new GuiTextureColored(PresetIcon.ICON_TICK.getTexture(), new GuiColorStatic(0xFF00FF00));
         IGuiTexture txCross = new GuiTextureColored(PresetIcon.ICON_CROSS.getTexture(), new GuiColorStatic(0xFFFF0000));
 
-        this.addPanel(new PanelGeneric(new GuiRectangle(0, 0, 16, 16, 0), new ItemTexture(new BigItemStack(Blocks.crafting_table))));
+        this.addPanel(new PanelGeneric(
+                new GuiRectangle(0, 0, 16, 16, 0), new ItemTexture(new BigItemStack(Blocks.crafting_table))));
         this.addPanel(new PanelGeneric(new GuiRectangle(10, 10, 6, 6, 0), task.allowCraft ? txTick : txCross));
 
-        this.addPanel(new PanelGeneric(new GuiRectangle(24, 0, 16, 16, 0), new ItemTexture(new BigItemStack(Blocks.furnace))));
+        this.addPanel(new PanelGeneric(
+                new GuiRectangle(24, 0, 16, 16, 0), new ItemTexture(new BigItemStack(Blocks.furnace))));
         this.addPanel(new PanelGeneric(new GuiRectangle(34, 10, 6, 6, 0), task.allowSmelt ? txTick : txCross));
 
-        this.addPanel(new PanelGeneric(new GuiRectangle(48, 0, 16, 16, 0), new ItemTexture(new BigItemStack(Blocks.anvil))));
+        this.addPanel(
+                new PanelGeneric(new GuiRectangle(48, 0, 16, 16, 0), new ItemTexture(new BigItemStack(Blocks.anvil))));
         this.addPanel(new PanelGeneric(new GuiRectangle(58, 10, 6, 6, 0), task.allowAnvil ? txTick : txCross));
 
         int listW = initialRect.getWidth();
 
-        for(int i = 0; i < task.requiredItems.size(); i++)
-        {
+        for (int i = 0; i < task.requiredItems.size(); i++) {
             BigItemStack stack = task.requiredItems.get(i);
 
             GuiRectangle guiRectangle = new GuiRectangle(0, i * 28 + 24, 28, 28, 0);
@@ -74,24 +70,27 @@ public class PanelTaskCrafting extends CanvasMinimum
 
             sb.append(stack.getBaseStack().getDisplayName());
 
-			if(stack.hasOreDict()) sb.append(" (").append(stack.getOreDict()).append(")");
+            if (stack.hasOreDict()) sb.append(" (").append(stack.getOreDict()).append(")");
 
-			sb.append("\n").append(progress[i]).append("/").append(stack.stackSize).append("\n");
+            sb.append("\n")
+                    .append(progress[i])
+                    .append("/")
+                    .append(stack.stackSize)
+                    .append("\n");
 
-			if(isComplete || progress[i] >= stack.stackSize)
-			{
-				sb.append(EnumChatFormatting.GREEN).append(QuestTranslation.translate("betterquesting.tooltip.complete"));
-			} else
-			{
-				sb.append(EnumChatFormatting.RED).append(QuestTranslation.translate("betterquesting.tooltip.incomplete"));
-			}
+            if (isComplete || progress[i] >= stack.stackSize) {
+                sb.append(EnumChatFormatting.GREEN)
+                        .append(QuestTranslation.translate("betterquesting.tooltip.complete"));
+            } else {
+                sb.append(EnumChatFormatting.RED)
+                        .append(QuestTranslation.translate("betterquesting.tooltip.incomplete"));
+            }
 
             PanelTextBox text = new PanelTextBox(new GuiRectangle(36, i * 28 + 24, listW - 36, 28, 0), sb.toString());
-			text.setColor(PresetColor.TEXT_MAIN.getColor());
-			this.addPanel(text);
+            text.setColor(PresetColor.TEXT_MAIN.getColor());
+            this.addPanel(text);
         }
 
         recalcSizes();
     }
-
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskFluid.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskFluid.java
@@ -2,39 +2,32 @@ package bq_standard.client.gui.tasks;
 
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api2.client.gui.misc.*;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
-import betterquesting.api2.client.gui.panels.bars.PanelVScrollBar;
 import betterquesting.api2.client.gui.panels.content.PanelFluidSlot;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
-import betterquesting.api2.client.gui.panels.lists.CanvasScrolling;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.utils.QuestTranslation;
 import bq_standard.core.BQ_Standard;
 import bq_standard.tasks.TaskFluid;
 import codechicken.nei.recipe.GuiCraftingRecipe;
 import cpw.mods.fml.common.Optional.Method;
+import java.util.UUID;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.fluids.FluidStack;
 
-import java.util.UUID;
-
-public class PanelTaskFluid extends CanvasMinimum
-{
+public class PanelTaskFluid extends CanvasMinimum {
     private final TaskFluid task;
     private final IGuiRect initialRect;
-    
-    public PanelTaskFluid(IGuiRect rect, TaskFluid task)
-    {
+
+    public PanelTaskFluid(IGuiRect rect, TaskFluid task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int listW = initialRect.getWidth();
 
@@ -42,46 +35,46 @@ public class PanelTaskFluid extends CanvasMinimum
         int[] progress = task.getUsersProgress(uuid);
         boolean isComplete = task.isComplete(uuid);
 
-        String sCon = (task.consume ? EnumChatFormatting.RED : EnumChatFormatting.GREEN) + QuestTranslation.translate(task.consume ? "gui.yes" : "gui.no");
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, 0, 0, listW, 12, 0), QuestTranslation.translate("bq_standard.btn.consume", sCon)).setColor(PresetColor.TEXT_MAIN.getColor()));
+        String sCon = (task.consume ? EnumChatFormatting.RED : EnumChatFormatting.GREEN)
+                + QuestTranslation.translate(task.consume ? "gui.yes" : "gui.no");
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, 0, 0, listW, 12, 0),
+                        QuestTranslation.translate("bq_standard.btn.consume", sCon))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
 
-
-        for(int i = 0; i < task.requiredFluids.size(); i++)
-        {
+        for (int i = 0; i < task.requiredFluids.size(); i++) {
             FluidStack stack = task.requiredFluids.get(i);
-            
-            if(stack == null)
-            {
+
+            if (stack == null) {
                 continue;
             }
-    
+
             PanelFluidSlot slot = new PanelFluidSlot(new GuiRectangle(0, i * 28 + 12, 28, 28, 0), -1, stack);
-            if(BQ_Standard.hasNEI) slot.setCallback(this::lookupRecipe);
+            if (BQ_Standard.hasNEI) slot.setCallback(this::lookupRecipe);
             this.addPanel(slot);
-            
+
             StringBuilder sb = new StringBuilder();
-            
+
             sb.append(stack.getLocalizedName()).append("\n");
-			sb.append(progress[i]).append("/").append(stack.amount).append("mB\n");
-			
-			if(progress[i] >= stack.amount || isComplete)
-			{
-				sb.append(EnumChatFormatting.GREEN).append(QuestTranslation.translate("betterquesting.tooltip.complete"));
-			} else
-			{
-				sb.append(EnumChatFormatting.RED).append(QuestTranslation.translate("betterquesting.tooltip.incomplete"));
-			}
-            
+            sb.append(progress[i]).append("/").append(stack.amount).append("mB\n");
+
+            if (progress[i] >= stack.amount || isComplete) {
+                sb.append(EnumChatFormatting.GREEN)
+                        .append(QuestTranslation.translate("betterquesting.tooltip.complete"));
+            } else {
+                sb.append(EnumChatFormatting.RED)
+                        .append(QuestTranslation.translate("betterquesting.tooltip.incomplete"));
+            }
+
             PanelTextBox text = new PanelTextBox(new GuiRectangle(36, i * 28 + 12, listW - 36, 28, 0), sb.toString());
-			text.setColor(PresetColor.TEXT_MAIN.getColor());
-			this.addPanel(text);
+            text.setColor(PresetColor.TEXT_MAIN.getColor());
+            this.addPanel(text);
         }
         recalcSizes();
     }
-    
+
     @Method(modid = "NotEnoughItems")
-    private void lookupRecipe(FluidStack fluid)
-    {
+    private void lookupRecipe(FluidStack fluid) {
         GuiCraftingRecipe.openRecipeGui("fluid", fluid);
     }
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskHunt.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskHunt.java
@@ -3,10 +3,8 @@ package bq_standard.client.gui.tasks;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api2.client.gui.controls.io.ValueFuncIO;
 import betterquesting.api2.client.gui.misc.GuiAlign;
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelEntityPreview;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
@@ -16,43 +14,44 @@ import bq_standard.tasks.TaskHunt;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
-import org.lwjgl.util.vector.Vector4f;
 
-public class PanelTaskHunt extends CanvasMinimum
-{
+public class PanelTaskHunt extends CanvasMinimum {
     private final TaskHunt task;
     private final IGuiRect initialRect;
-    
-    public PanelTaskHunt(IGuiRect rect, TaskHunt task)
-    {
+
+    public PanelTaskHunt(IGuiRect rect, TaskHunt task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
-    
+
         Entity target;
-        
-        if(EntityList.stringToClassMapping.containsKey(task.idName))
-        {
+
+        if (EntityList.stringToClassMapping.containsKey(task.idName)) {
             target = EntityList.createEntityByName(task.idName, Minecraft.getMinecraft().theWorld);
-            if(target != null) target.readFromNBT(task.targetTags);
-        } else
-        {
+            if (target != null) target.readFromNBT(task.targetTags);
+        } else {
             target = null;
         }
-        
+
         int progress = task.getUsersProgress(QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer));
-		String tnm = target != null? target.getCommandSenderName() : task.idName;
-        
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, 0, 0, width, 12, 0), QuestTranslation.translate("bq_standard.gui.kill", tnm) + " " + progress + "/" + task.required).setAlignment(1).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        if(target != null) this.addPanel(new PanelEntityPreview(new GuiTransform(GuiAlign.TOP_LEFT, 0, 16, width, 64, 0), target).setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() -> (float)(Minecraft.getSystemTime()%30000L / 30000D * 360D))));
+        String tnm = target != null ? target.getCommandSenderName() : task.idName;
+
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, 0, 0, width, 12, 0),
+                        QuestTranslation.translate("bq_standard.gui.kill", tnm) + " " + progress + "/" + task.required)
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        if (target != null)
+            this.addPanel(new PanelEntityPreview(new GuiTransform(GuiAlign.TOP_LEFT, 0, 16, width, 64, 0), target)
+                    .setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() ->
+                            (float) (Minecraft.getSystemTime() % 30000L / 30000D * 360D))));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskInteractEntity.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskInteractEntity.java
@@ -3,10 +3,8 @@ package bq_standard.client.gui.tasks;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api2.client.gui.controls.io.ValueFuncIO;
 import betterquesting.api2.client.gui.misc.GuiAlign;
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelEntityPreview;
 import betterquesting.api2.client.gui.panels.content.PanelGeneric;
@@ -19,61 +17,72 @@ import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import bq_standard.client.theme.BQSTextures;
 import bq_standard.tasks.TaskInteractEntity;
+import java.util.UUID;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 
-import java.util.UUID;
-
-public class PanelTaskInteractEntity extends CanvasMinimum
-{
+public class PanelTaskInteractEntity extends CanvasMinimum {
     private final TaskInteractEntity task;
     private final IGuiRect initialRect;
-    
-    public PanelTaskInteractEntity(IGuiRect rect, TaskInteractEntity task)
-    {
+
+    public PanelTaskInteractEntity(IGuiRect rect, TaskInteractEntity task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
-        
-        this.addPanel(new PanelItemSlot(new GuiTransform(GuiAlign.TOP_LEFT, 0, 0, 32, 32, 0), -1, task.targetItem, false, true));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 32, 8, 16, 16, 0), PresetIcon.ICON_RIGHT.getTexture()));
-        
+
+        this.addPanel(new PanelItemSlot(
+                new GuiTransform(GuiAlign.TOP_LEFT, 0, 0, 32, 32, 0), -1, task.targetItem, false, true));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, 32, 8, 16, 16, 0), PresetIcon.ICON_RIGHT.getTexture()));
+
         UUID playerID = QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer);
         int prog = task.getUsersProgress(playerID);
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, -14, 32, 14, 0), prog + "/" + task.required).setAlignment(1).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 0, 48, 24, 24, 0), BQSTextures.HAND_LEFT.getTexture()));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 24, 48, 24, 24, 0), BQSTextures.HAND_RIGHT.getTexture()));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 0, 72, 24, 24, 0), BQSTextures.ATK_SYMB.getTexture()));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 24, 72, 24, 24, 0), BQSTextures.USE_SYMB.getTexture()));
-        
+        this.addPanel(
+                new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, -14, 32, 14, 0), prog + "/" + task.required)
+                        .setAlignment(1)
+                        .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, 0, 48, 24, 24, 0), BQSTextures.HAND_LEFT.getTexture()));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, 24, 48, 24, 24, 0), BQSTextures.HAND_RIGHT.getTexture()));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, 0, 72, 24, 24, 0), BQSTextures.ATK_SYMB.getTexture()));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, 24, 72, 24, 24, 0), BQSTextures.USE_SYMB.getTexture()));
+
         IGuiTexture txTick = new GuiTextureColored(PresetIcon.ICON_TICK.getTexture(), new GuiColorStatic(0xFF00FF00));
         IGuiTexture txCross = new GuiTextureColored(PresetIcon.ICON_CROSS.getTexture(), new GuiColorStatic(0xFFFF0000));
-        
-        //this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 16, 64, 8, 8, 0), task.useOffHand ? txTick : txCross));
-        //this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 40, 64, 8, 8, 0), task.useMainHand ? txTick : txCross));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 16, 88, 8, 8, 0), task.onHit ? txTick : txCross));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 40, 88, 8, 8, 0), task.onInteract ? txTick : txCross));
-        
+
+        // this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 16, 64, 8, 8, 0), task.useOffHand ? txTick
+        // : txCross));
+        // this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 40, 64, 8, 8, 0), task.useMainHand ?
+        // txTick : txCross));
+        this.addPanel(
+                new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, 16, 88, 8, 8, 0), task.onHit ? txTick : txCross));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, 40, 88, 8, 8, 0), task.onInteract ? txTick : txCross));
+
         Entity target;
-        
-        if(EntityList.stringToClassMapping.containsKey(task.entityID))
-        {
+
+        if (EntityList.stringToClassMapping.containsKey(task.entityID)) {
             target = EntityList.createEntityByName(task.entityID, Minecraft.getMinecraft().theWorld);
-            if(target != null) target.readFromNBT(task.entityTags);
-        } else
-        {
+            if (target != null) target.readFromNBT(task.entityTags);
+        } else {
             target = null;
         }
-        
-        if(target != null) this.addPanel(new PanelEntityPreview(new GuiTransform(GuiAlign.TOP_LEFT, 48, 0, initialRect.getWidth() - 48, 96, 0), target).setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() -> (float)(Minecraft.getSystemTime()%30000L / 30000D * 360D))));
+
+        if (target != null)
+            this.addPanel(new PanelEntityPreview(
+                            new GuiTransform(GuiAlign.TOP_LEFT, 48, 0, initialRect.getWidth() - 48, 96, 0), target)
+                    .setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() ->
+                            (float) (Minecraft.getSystemTime() % 30000L / 30000D * 360D))));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskInteractItem.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskInteractItem.java
@@ -4,7 +4,6 @@ import betterquesting.api.api.QuestingAPI;
 import betterquesting.api2.client.gui.misc.GuiAlign;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelGeneric;
 import betterquesting.api2.client.gui.panels.content.PanelItemSlot;
@@ -16,49 +15,69 @@ import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.client.gui.themes.presets.PresetIcon;
 import bq_standard.client.theme.BQSTextures;
 import bq_standard.tasks.TaskInteractItem;
+import java.util.UUID;
 import net.minecraft.client.Minecraft;
 
-import java.util.UUID;
-
-public class PanelTaskInteractItem extends CanvasMinimum
-{
+public class PanelTaskInteractItem extends CanvasMinimum {
     private final TaskInteractItem task;
     private final IGuiRect initialRect;
-    
-    public PanelTaskInteractItem(IGuiRect rect, TaskInteractItem task)
-    {
+
+    public PanelTaskInteractItem(IGuiRect rect, TaskInteractItem task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
         int centerWidth = width / 2;
 
-        this.addPanel(new PanelItemSlot(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 48, 0, 32, 32, 0), -1, task.targetItem, false, true));
-        this.addPanel(new PanelItemSlot(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth + 16, 0, 32, 32, 0), -1, task.targetBlock.getItemStack(), false, true));
-        
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 8, 0, 16, 16, 0), PresetIcon.ICON_RIGHT.getTexture()));
+        this.addPanel(new PanelItemSlot(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 48, 0, 32, 32, 0), -1, task.targetItem, false, true));
+        this.addPanel(new PanelItemSlot(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth + 16, 0, 32, 32, 0),
+                -1,
+                task.targetBlock.getItemStack(),
+                false,
+                true));
+
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 8, 0, 16, 16, 0),
+                PresetIcon.ICON_RIGHT.getTexture()));
         UUID playerID = QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer);
         int prog = task.getUsersProgress(playerID);
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 16, 18, 32, 14, 0), prog + "/" + task.required).setAlignment(1).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 48, 40, 24, 24, 0), BQSTextures.HAND_LEFT.getTexture()));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 24, 40, 24, 24, 0), BQSTextures.HAND_RIGHT.getTexture()));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth, 40, 24, 24, 0), BQSTextures.ATK_SYMB.getTexture()));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth + 24, 40, 24, 24, 0), BQSTextures.USE_SYMB.getTexture()));
-        
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 16, 18, 32, 14, 0),
+                        prog + "/" + task.required)
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 48, 40, 24, 24, 0),
+                BQSTextures.HAND_LEFT.getTexture()));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 24, 40, 24, 24, 0),
+                BQSTextures.HAND_RIGHT.getTexture()));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth, 40, 24, 24, 0), BQSTextures.ATK_SYMB.getTexture()));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth + 24, 40, 24, 24, 0),
+                BQSTextures.USE_SYMB.getTexture()));
+
         IGuiTexture txTick = new GuiTextureColored(PresetIcon.ICON_TICK.getTexture(), new GuiColorStatic(0xFF00FF00));
         IGuiTexture txCross = new GuiTextureColored(PresetIcon.ICON_CROSS.getTexture(), new GuiColorStatic(0xFFFF0000));
-        
-        //this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 32, 56, 8, 8, 0), task.useOffHand ? txTick : txCross));
-        //this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 8, 56, 8, 8, 0), task.useMainHand ? txTick : txCross));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth + 16, 56, 8, 8, 0), task.onHit ? txTick : txCross));
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth + 40, 56, 8, 8, 0), task.onInteract ? txTick : txCross));
+
+        // this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 32, 56, 8, 8, 0),
+        // task.useOffHand ? txTick : txCross));
+        // this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, centerWidth - 8, 56, 8, 8, 0),
+        // task.useMainHand ? txTick : txCross));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth + 16, 56, 8, 8, 0), task.onHit ? txTick : txCross));
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, centerWidth + 40, 56, 8, 8, 0),
+                task.onInteract ? txTick : txCross));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskLocation.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskLocation.java
@@ -3,10 +3,8 @@ package bq_standard.client.gui.tasks;
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.utils.RenderUtils;
 import betterquesting.api2.client.gui.misc.GuiAlign;
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelGeneric;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
@@ -15,80 +13,76 @@ import betterquesting.api2.client.gui.resources.textures.IGuiTexture;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.utils.QuestTranslation;
 import bq_standard.tasks.TaskLocation;
+import java.awt.*;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
 import org.apache.commons.lang3.StringUtils;
-import org.lwjgl.Sys;
 import org.lwjgl.opengl.GL11;
-import org.lwjgl.util.vector.Vector4f;
 
-import java.awt.*;
-
-public class PanelTaskLocation extends CanvasMinimum
-{
+public class PanelTaskLocation extends CanvasMinimum {
     private final TaskLocation task;
     private final IGuiRect initialRect;
-    
-    public PanelTaskLocation(IGuiRect rect, TaskLocation task)
-    {
+
+    public PanelTaskLocation(IGuiRect rect, TaskLocation task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
-        
+
         String desc = QuestTranslation.translate(task.name);
-        
-        if(!task.hideInfo)
-        {
+
+        if (!task.hideInfo) {
             desc += " (" + TaskLocation.getDimName(task.dim) + ")";
-            
-            if(task.range >= 0)
-            {
-                desc += "\n" + QuestTranslation.translate("bq_standard.gui.location", "(" + task.x + ", " + task.y + ", " + task.z + ")");
-                desc += "\n" + QuestTranslation.translate("bq_standard.gui.distance", (int)Minecraft.getMinecraft().thePlayer.getDistance(task.x, task.y, task.z) + "m");
+
+            if (task.range >= 0) {
+                desc += "\n"
+                        + QuestTranslation.translate(
+                                "bq_standard.gui.location", "(" + task.x + ", " + task.y + ", " + task.z + ")");
+                desc += "\n"
+                        + QuestTranslation.translate(
+                                "bq_standard.gui.distance",
+                                (int) Minecraft.getMinecraft().thePlayer.getDistance(task.x, task.y, task.z) + "m");
             }
         }
-        
-        if(task.isComplete(QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer)))
-        {
-            desc += "\n" + EnumChatFormatting.BOLD + EnumChatFormatting.GREEN + QuestTranslation.translate("bq_standard.gui.found");
-        } else
-        {
-            desc += "\n" + EnumChatFormatting.BOLD + EnumChatFormatting.RED + QuestTranslation.translate("bq_standard.gui.undiscovered");
+
+        if (task.isComplete(QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer))) {
+            desc += "\n" + EnumChatFormatting.BOLD + EnumChatFormatting.GREEN
+                    + QuestTranslation.translate("bq_standard.gui.found");
+        } else {
+            desc += "\n" + EnumChatFormatting.BOLD + EnumChatFormatting.RED
+                    + QuestTranslation.translate("bq_standard.gui.undiscovered");
         }
 
         int textHeight = (StringUtils.countMatches(desc, "\n") + 1) * 12;
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, 0, width, textHeight, 0), desc).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        IGuiTexture texCompass = new IGuiTexture()
-        {
+        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, 0, width, textHeight, 0), desc)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        IGuiTexture texCompass = new IGuiTexture() {
             @Override
-            public void drawTexture(int x, int y, int width, int height, float zDepth, float partialTick)
-            {
+            public void drawTexture(int x, int y, int width, int height, float zDepth, float partialTick) {
                 drawTexture(x, y, width, height, zDepth, partialTick, null);
             }
-    
+
             @Override
-            public void drawTexture(int x, int y, int width, int height, float zDepth, float partialTick, IGuiColor color)
-            {
+            public void drawTexture(
+                    int x, int y, int width, int height, float zDepth, float partialTick, IGuiColor color) {
                 Minecraft mc = Minecraft.getMinecraft();
-                
-		        double la = Math.atan2(task.z - mc.thePlayer.posZ, task.x - mc.thePlayer.posX);
-                int radius = width/2 - 12;
-                int cx = x + width/2;
-                int cy = y + height/2;
-                int dx = (int)(Math.cos(la) * radius);
-                int dy = (int)(Math.sin(la) * -radius);
+
+                double la = Math.atan2(task.z - mc.thePlayer.posZ, task.x - mc.thePlayer.posX);
+                int radius = width / 2 - 12;
+                int cx = x + width / 2;
+                int cy = y + height / 2;
+                int dx = (int) (Math.cos(la) * radius);
+                int dy = (int) (Math.sin(la) * -radius);
                 int txtClr = color == null ? 0xFFFFFFFF : color.getRGB();
-                
+
                 Gui.drawRect(cx - radius, cy - radius, cx + radius, cy + radius, Color.BLACK.getRGB());
                 RenderUtils.DrawLine(cx - radius, cy - radius, cx + radius, cy - radius, 4, Color.WHITE.getRGB());
                 RenderUtils.DrawLine(cx - radius, cy - radius, cx - radius, cy + radius, 4, Color.WHITE.getRGB());
@@ -98,34 +92,34 @@ public class PanelTaskLocation extends CanvasMinimum
                 mc.fontRenderer.drawString(EnumChatFormatting.BOLD + "S", cx - 4, cy + radius + 2, txtClr);
                 mc.fontRenderer.drawString(EnumChatFormatting.BOLD + "E", cx + radius + 2, cy - 4, txtClr);
                 mc.fontRenderer.drawString(EnumChatFormatting.BOLD + "W", cx - radius - 8, cy - 4, txtClr);
-                
-                if(task.hideInfo || task.range < 0 || mc.thePlayer.dimension != task.dim)
-                {
+
+                if (task.hideInfo || task.range < 0 || mc.thePlayer.dimension != task.dim) {
                     GL11.glPushMatrix();
                     GL11.glScalef(2F, 2F, 2F);
-                    mc.fontRenderer.drawString(EnumChatFormatting.BOLD + "?", cx/2 - 4, cy/2 - 4 , Color.RED.getRGB());
+                    mc.fontRenderer.drawString(
+                            EnumChatFormatting.BOLD + "?", cx / 2 - 4, cy / 2 - 4, Color.RED.getRGB());
                     GL11.glPopMatrix();
-                } else
-                {
+                } else {
                     RenderUtils.DrawLine(cx, cy, cx + dx, cy - dy, 4, Color.RED.getRGB());
                 }
             }
-    
+
             @Override
-            public ResourceLocation getTexture()
-            {
+            public ResourceLocation getTexture() {
                 return null;
             }
-    
+
             @Override
-            public IGuiRect getBounds()
-            {
+            public IGuiRect getBounds() {
                 return null;
             }
         };
-        
+
         int innerSize = Math.min(Math.min(initialRect.getWidth(), 128), initialRect.getHeight() - textHeight);
-        PanelGeneric innerCanvas = new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, (width - innerSize) / 2, textHeight, innerSize, innerSize, 0), texCompass, PresetColor.TEXT_MAIN.getColor());
+        PanelGeneric innerCanvas = new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, (width - innerSize) / 2, textHeight, innerSize, innerSize, 0),
+                texCompass,
+                PresetColor.TEXT_MAIN.getColor());
         this.addPanel(innerCanvas);
         recalcSizes();
     }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskMeeting.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskMeeting.java
@@ -2,10 +2,8 @@ package bq_standard.client.gui.tasks;
 
 import betterquesting.api2.client.gui.controls.io.ValueFuncIO;
 import betterquesting.api2.client.gui.misc.GuiAlign;
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelEntityPreview;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
@@ -16,40 +14,42 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 
-public class PanelTaskMeeting extends CanvasMinimum
-{
+public class PanelTaskMeeting extends CanvasMinimum {
     private final TaskMeeting task;
     private final IGuiRect initialRect;
-    
-    public PanelTaskMeeting(IGuiRect rect, TaskMeeting task)
-    {
+
+    public PanelTaskMeeting(IGuiRect rect, TaskMeeting task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
-    
+
         Entity target;
-        
-        if(EntityList.stringToClassMapping.containsKey(task.idName))
-        {
+
+        if (EntityList.stringToClassMapping.containsKey(task.idName)) {
             target = EntityList.createEntityByName(task.idName, Minecraft.getMinecraft().theWorld);
-            if(target != null) target.readFromNBT(task.targetTags);
-        } else
-        {
+            if (target != null) target.readFromNBT(task.targetTags);
+        } else {
             target = null;
         }
-        
-		String tnm = target != null? target.getCommandSenderName() : task.idName;
-        
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE,0, 0, width, 16, 0), QuestTranslation.translate("bq_standard.gui.meet", tnm) + " x" + task.amount).setAlignment(1).setColor(PresetColor.TEXT_MAIN.getColor()));
-        
-        if(target != null) this.addPanel(new PanelEntityPreview(new GuiTransform(GuiAlign.TOP_LEFT, 0, 16, width, 64, 0), target).setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() -> (float)(Minecraft.getSystemTime()%30000L / 30000D * 360D))));
+
+        String tnm = target != null ? target.getCommandSenderName() : task.idName;
+
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, 0, 0, width, 16, 0),
+                        QuestTranslation.translate("bq_standard.gui.meet", tnm) + " x" + task.amount)
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+
+        if (target != null)
+            this.addPanel(new PanelEntityPreview(new GuiTransform(GuiAlign.TOP_LEFT, 0, 16, width, 64, 0), target)
+                    .setRotationDriven(new ValueFuncIO<>(() -> 15F), new ValueFuncIO<>(() ->
+                            (float) (Minecraft.getSystemTime() % 30000L / 30000D * 360D))));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskRetrieval.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskRetrieval.java
@@ -8,30 +8,24 @@ import betterquesting.api2.client.gui.panels.content.PanelItemSlot;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import betterquesting.api2.utils.QuestTranslation;
-import bq_standard.client.gui.panels.content.PanelInteractiveItemSlot;
 import bq_standard.client.gui.panels.content.PanelItemSlotBuilder;
-import bq_standard.core.BQ_Standard;
 import bq_standard.tasks.TaskRetrieval;
+import java.util.UUID;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.EnumChatFormatting;
 
-import java.util.UUID;
-
-public class PanelTaskRetrieval extends CanvasMinimum
-{
+public class PanelTaskRetrieval extends CanvasMinimum {
     private final TaskRetrieval task;
     private final IGuiRect initialRect;
 
-    public PanelTaskRetrieval(IGuiRect rect, TaskRetrieval task)
-    {
+    public PanelTaskRetrieval(IGuiRect rect, TaskRetrieval task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
 
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int listW = initialRect.getWidth();
 
@@ -39,15 +33,17 @@ public class PanelTaskRetrieval extends CanvasMinimum
         int[] progress = task.getUsersProgress(uuid);
         boolean isComplete = task.isComplete(uuid);
 
-        String sCon = (task.consume ? EnumChatFormatting.RED : EnumChatFormatting.GREEN) + QuestTranslation.translate(task.consume ? "gui.yes" : "gui.no");
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_EDGE, 0, 0, listW, 16, 0), QuestTranslation.translate("bq_standard.btn.consume", sCon)).setColor(PresetColor.TEXT_MAIN.getColor()));
+        String sCon = (task.consume ? EnumChatFormatting.RED : EnumChatFormatting.GREEN)
+                + QuestTranslation.translate(task.consume ? "gui.yes" : "gui.no");
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_EDGE, 0, 0, listW, 16, 0),
+                        QuestTranslation.translate("bq_standard.btn.consume", sCon))
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
 
-        for(int i = 0; i < task.requiredItems.size(); i++)
-        {
+        for (int i = 0; i < task.requiredItems.size(); i++) {
             BigItemStack stack = task.requiredItems.get(i);
 
-            if(stack == null)
-            {
+            if (stack == null) {
                 continue;
             }
 
@@ -61,24 +57,27 @@ public class PanelTaskRetrieval extends CanvasMinimum
 
             sb.append(stack.getBaseStack().getDisplayName());
 
-			if(stack.hasOreDict()) sb.append(" (").append(stack.getOreDict()).append(")");
+            if (stack.hasOreDict()) sb.append(" (").append(stack.getOreDict()).append(")");
 
-			sb.append("\n").append(progress[i]).append("/").append(stack.stackSize).append("\n");
+            sb.append("\n")
+                    .append(progress[i])
+                    .append("/")
+                    .append(stack.stackSize)
+                    .append("\n");
 
-			if(isComplete || progress[i] >= stack.stackSize)
-			{
-				sb.append(EnumChatFormatting.GREEN).append(QuestTranslation.translate("betterquesting.tooltip.complete"));
-			} else
-			{
-				sb.append(EnumChatFormatting.RED).append(QuestTranslation.translate("betterquesting.tooltip.incomplete"));
-			}
+            if (isComplete || progress[i] >= stack.stackSize) {
+                sb.append(EnumChatFormatting.GREEN)
+                        .append(QuestTranslation.translate("betterquesting.tooltip.complete"));
+            } else {
+                sb.append(EnumChatFormatting.RED)
+                        .append(QuestTranslation.translate("betterquesting.tooltip.incomplete"));
+            }
 
             PanelTextBox text = new PanelTextBox(new GuiRectangle(32, i * 32 + 16, listW - 28, 28, 0), sb.toString());
-			text.setColor(PresetColor.TEXT_MAIN.getColor());
-			this.addPanel(text);
+            text.setColor(PresetColor.TEXT_MAIN.getColor());
+            this.addPanel(text);
         }
 
         recalcSizes();
     }
-
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskScoreboard.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskScoreboard.java
@@ -1,58 +1,54 @@
 package bq_standard.client.gui.tasks;
 
 import betterquesting.api.api.QuestingAPI;
-import betterquesting.api.questing.IQuest;
 import betterquesting.api2.client.gui.misc.GuiAlign;
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.content.PanelTextBox;
 import betterquesting.api2.client.gui.themes.presets.PresetColor;
 import bq_standard.ScoreboardBQ;
 import bq_standard.tasks.TaskScoreboard;
+import java.text.DecimalFormat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.EnumChatFormatting;
-import org.lwjgl.util.vector.Vector4f;
 
-import java.text.DecimalFormat;
-
-public class PanelTaskScoreboard extends CanvasMinimum
-{
+public class PanelTaskScoreboard extends CanvasMinimum {
     private final TaskScoreboard task;
     private final IGuiRect initialRect;
 
-    public PanelTaskScoreboard(IGuiRect rect, TaskScoreboard task)
-    {
+    public PanelTaskScoreboard(IGuiRect rect, TaskScoreboard task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
 
-		int score = ScoreboardBQ.INSTANCE.getScore(QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer), task.scoreName);
-		DecimalFormat df = new DecimalFormat("0.##");
-		String value = df.format(score/task.conversion) + task.suffix;
-		
-		if(task.operation.checkValues(score, task.target))
-		{
-			value = EnumChatFormatting.GREEN + value;
-		} else
-		{
-			value = EnumChatFormatting.RED + value;
-		}
-		
-		String txt2 = EnumChatFormatting.BOLD + value + " " + EnumChatFormatting.RESET + task.operation.GetText() + " " + df.format(task.target/task.conversion) + task.suffix;
-		
-		// TODO: Add x2 scale when supported
-		this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, 0, width, 16, 0), task.scoreDisp).setAlignment(1).setColor(PresetColor.TEXT_MAIN.getColor()));
-		this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, 16, width, 16, 0), txt2).setAlignment(1).setColor(PresetColor.TEXT_MAIN.getColor()));
-		recalcSizes();
+        int score = ScoreboardBQ.INSTANCE.getScore(
+                QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer), task.scoreName);
+        DecimalFormat df = new DecimalFormat("0.##");
+        String value = df.format(score / task.conversion) + task.suffix;
+
+        if (task.operation.checkValues(score, task.target)) {
+            value = EnumChatFormatting.GREEN + value;
+        } else {
+            value = EnumChatFormatting.RED + value;
+        }
+
+        String txt2 = EnumChatFormatting.BOLD + value + " " + EnumChatFormatting.RESET + task.operation.GetText() + " "
+                + df.format(task.target / task.conversion) + task.suffix;
+
+        // TODO: Add x2 scale when supported
+        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, 0, width, 16, 0), task.scoreDisp)
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, 16, width, 16, 0), txt2)
+                .setAlignment(1)
+                .setColor(PresetColor.TEXT_MAIN.getColor()));
+        recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/gui/tasks/PanelTaskXP.java
+++ b/src/main/java/bq_standard/client/gui/tasks/PanelTaskXP.java
@@ -4,10 +4,8 @@ import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api2.client.gui.controls.io.ValueFuncIO;
 import betterquesting.api2.client.gui.misc.GuiAlign;
-import betterquesting.api2.client.gui.misc.GuiPadding;
 import betterquesting.api2.client.gui.misc.GuiTransform;
 import betterquesting.api2.client.gui.misc.IGuiRect;
-import betterquesting.api2.client.gui.panels.CanvasEmpty;
 import betterquesting.api2.client.gui.panels.CanvasMinimum;
 import betterquesting.api2.client.gui.panels.bars.PanelHBarFill;
 import betterquesting.api2.client.gui.panels.content.PanelGeneric;
@@ -17,42 +15,43 @@ import betterquesting.api2.client.gui.resources.textures.ItemTexture;
 import bq_standard.XPHelper;
 import bq_standard.tasks.TaskXP;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.init.Items;
 import net.minecraft.util.EnumChatFormatting;
-import org.lwjgl.util.vector.Vector4f;
 
-public class PanelTaskXP extends CanvasMinimum
-{
+public class PanelTaskXP extends CanvasMinimum {
     private final TaskXP task;
     private final IGuiRect initialRect;
-    
-    public PanelTaskXP(IGuiRect rect, TaskXP task)
-    {
+
+    public PanelTaskXP(IGuiRect rect, TaskXP task) {
         super(rect);
         this.task = task;
         initialRect = rect;
     }
-    
+
     @Override
-    public void initPanel()
-    {
+    public void initPanel() {
         super.initPanel();
         int width = initialRect.getWidth();
-        
-        this.addPanel(new PanelGeneric(new GuiTransform(GuiAlign.TOP_LEFT, (width - 32) / 2, 0, 32, 32, 0), new ItemTexture(new BigItemStack(Items.experience_bottle))));
-        
-		long xp = task.getUsersProgress(QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer));
-		xp = !task.levels? xp : XPHelper.getXPLevel(xp);
-		final float xpPercent = (float)((double)xp/(double)task.amount);
+
+        this.addPanel(new PanelGeneric(
+                new GuiTransform(GuiAlign.TOP_LEFT, (width - 32) / 2, 0, 32, 32, 0),
+                new ItemTexture(new BigItemStack(Items.experience_bottle))));
+
+        long xp = task.getUsersProgress(QuestingAPI.getQuestingUUID(Minecraft.getMinecraft().thePlayer));
+        xp = !task.levels ? xp : XPHelper.getXPLevel(xp);
+        final float xpPercent = (float) ((double) xp / (double) task.amount);
 
         int barWidth = Math.min(128, width);
-        PanelHBarFill fillBar = new PanelHBarFill(new GuiTransform(GuiAlign.TOP_LEFT, (width - barWidth) / 2, 32, barWidth, 16, 0));
+        PanelHBarFill fillBar =
+                new PanelHBarFill(new GuiTransform(GuiAlign.TOP_LEFT, (width - barWidth) / 2, 32, barWidth, 16, 0));
         fillBar.setFillColor(new GuiColorStatic(0xFF00FF00));
         fillBar.setFillDriver(new ValueFuncIO<>(() -> xpPercent));
         this.addPanel(fillBar);
-        
-        this.addPanel(new PanelTextBox(new GuiTransform(GuiAlign.TOP_LEFT, 0, 36, width, 16, -1), EnumChatFormatting.BOLD + "" + xp + "/" + task.amount + (task.levels ? "L" : "XP")).setAlignment(1));
+
+        this.addPanel(new PanelTextBox(
+                        new GuiTransform(GuiAlign.TOP_LEFT, 0, 36, width, 16, -1),
+                        EnumChatFormatting.BOLD + "" + xp + "/" + task.amount + (task.levels ? "L" : "XP"))
+                .setAlignment(1));
         recalcSizes();
     }
 }

--- a/src/main/java/bq_standard/client/theme/BQSTextures.java
+++ b/src/main/java/bq_standard/client/theme/BQSTextures.java
@@ -9,41 +9,37 @@ import betterquesting.api2.client.gui.themes.IThemeRegistry;
 import bq_standard.core.BQ_Standard;
 import net.minecraft.util.ResourceLocation;
 
-public enum BQSTextures
-{
+public enum BQSTextures {
     LOOT_CHEST("loot_chest"),
     LOOT_GLOW("loot_glow"),
-    
+
     HAND_LEFT("hand_left"),
     HAND_RIGHT("hand_right"),
     ATK_SYMB("attack_symb"),
     USE_SYMB("use_symb");
-    
-    public static final ResourceLocation TX_UI_ELEMENTS = new ResourceLocation(BQ_Standard.MODID, "textures/gui/gui_elements.png");
-    
+
+    public static final ResourceLocation TX_UI_ELEMENTS =
+            new ResourceLocation(BQ_Standard.MODID, "textures/gui/gui_elements.png");
+
     private final ResourceLocation key;
-	
-	BQSTextures(String key)
-	{
-		this.key = new ResourceLocation(BQ_Standard.MODID, key);
-	}
-	
-	public IGuiTexture getTexture()
-	{
-		return QuestingAPI.getAPI(ApiReference.THEME_REG).getTexture(this.key);
-	}
-	
-	public ResourceLocation getKey()
-	{
-		return this.key;
-	}
-	
-	public static void registerTextures()
-    {
+
+    BQSTextures(String key) {
+        this.key = new ResourceLocation(BQ_Standard.MODID, key);
+    }
+
+    public IGuiTexture getTexture() {
+        return QuestingAPI.getAPI(ApiReference.THEME_REG).getTexture(this.key);
+    }
+
+    public ResourceLocation getKey() {
+        return this.key;
+    }
+
+    public static void registerTextures() {
         IThemeRegistry tReg = QuestingAPI.getAPI(ApiReference.THEME_REG);
         tReg.setDefaultTexture(LOOT_CHEST.key, new SimpleTexture(TX_UI_ELEMENTS, new GuiRectangle(0, 0, 128, 68)));
         tReg.setDefaultTexture(LOOT_GLOW.key, new SimpleTexture(TX_UI_ELEMENTS, new GuiRectangle(128, 0, 32, 32)));
-        
+
         tReg.setDefaultTexture(HAND_LEFT.key, new SimpleTexture(TX_UI_ELEMENTS, new GuiRectangle(0, 80, 16, 16)));
         tReg.setDefaultTexture(HAND_RIGHT.key, new SimpleTexture(TX_UI_ELEMENTS, new GuiRectangle(16, 80, 16, 16)));
         tReg.setDefaultTexture(ATK_SYMB.key, new SimpleTexture(TX_UI_ELEMENTS, new GuiRectangle(32, 80, 16, 16)));

--- a/src/main/java/bq_standard/commands/BQS_Commands.java
+++ b/src/main/java/bq_standard/commands/BQS_Commands.java
@@ -5,6 +5,7 @@ import betterquesting.api.utils.NBTConverter;
 import bq_standard.network.handlers.NetLootSync;
 import bq_standard.rewards.loot.LootRegistry;
 import com.google.gson.JsonObject;
+import java.io.File;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -14,91 +15,72 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 
-import java.io.File;
+public class BQS_Commands extends CommandBase {
+    @Override
+    public String getCommandName() {
+        return "bqs_loot";
+    }
 
-public class BQS_Commands extends CommandBase
-{
-	@Override
-	public String getCommandName()
-	{
-		return "bqs_loot";
-	}
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/bqs_loot default [save|load], /bqs_loot delete [all|<loot_id>]";
+    }
 
-	@Override
-	public String getCommandUsage(ICommandSender sender)
-	{
-		return "/bqs_loot default [save|load], /bqs_loot delete [all|<loot_id>]";
-	}
-	
-	@Override
-    public int getRequiredPermissionLevel()
-    {
+    @Override
+    public int getRequiredPermissionLevel() {
         return 2;
     }
 
-	@Override
-	public void processCommand(ICommandSender sender, String[] args) throws CommandException
-	{
-		if(args.length != 2)
-		{
-			throw new WrongUsageException(getCommandUsage(sender));
-		}
-		
-		if(args[0].equalsIgnoreCase("default"))
-		{
-			if(args[1].equalsIgnoreCase("save"))
-			{
-				NBTTagCompound jsonQ = new NBTTagCompound();
-				LootRegistry.INSTANCE.writeToNBT(jsonQ, null);
-				JsonHelper.WriteToFile(new File(MinecraftServer.getServer().getFile("config/betterquesting/"), "DefaultLoot.json"), NBTConverter.NBTtoJSON_Compound(jsonQ, new JsonObject(), true));
-				sender.addChatMessage(new ChatComponentText("Loot database set as global default"));
-			} else if(args[1].equalsIgnoreCase("load"))
-			{
-		    	File f1 = new File("config/betterquesting/DefaultLoot.json");
-				NBTTagCompound j1;
-				
-				if(f1.exists())
-				{
-					j1 = NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(f1), new NBTTagCompound(), true);
-					LootRegistry.INSTANCE.readFromNBT(j1, false);
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) throws CommandException {
+        if (args.length != 2) {
+            throw new WrongUsageException(getCommandUsage(sender));
+        }
+
+        if (args[0].equalsIgnoreCase("default")) {
+            if (args[1].equalsIgnoreCase("save")) {
+                NBTTagCompound jsonQ = new NBTTagCompound();
+                LootRegistry.INSTANCE.writeToNBT(jsonQ, null);
+                JsonHelper.WriteToFile(
+                        new File(MinecraftServer.getServer().getFile("config/betterquesting/"), "DefaultLoot.json"),
+                        NBTConverter.NBTtoJSON_Compound(jsonQ, new JsonObject(), true));
+                sender.addChatMessage(new ChatComponentText("Loot database set as global default"));
+            } else if (args[1].equalsIgnoreCase("load")) {
+                File f1 = new File("config/betterquesting/DefaultLoot.json");
+                NBTTagCompound j1;
+
+                if (f1.exists()) {
+                    j1 = NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(f1), new NBTTagCompound(), true);
+                    LootRegistry.INSTANCE.readFromNBT(j1, false);
                     NetLootSync.sendSync(null);
-					sender.addChatMessage(new ChatComponentText("Reloaded default loot database"));
-				} else
-				{
-					sender.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "No default loot currently set"));
-				}
-			} else
-			{
-				throw new WrongUsageException(getCommandUsage(sender));
-			}
-		} else if(args[0].equalsIgnoreCase("delete"))
-		{
-			if(args[1].equalsIgnoreCase("all"))
-			{
-				LootRegistry.INSTANCE.reset();
+                    sender.addChatMessage(new ChatComponentText("Reloaded default loot database"));
+                } else {
+                    sender.addChatMessage(
+                            new ChatComponentText(EnumChatFormatting.RED + "No default loot currently set"));
+                }
+            } else {
+                throw new WrongUsageException(getCommandUsage(sender));
+            }
+        } else if (args[0].equalsIgnoreCase("delete")) {
+            if (args[1].equalsIgnoreCase("all")) {
+                LootRegistry.INSTANCE.reset();
                 NetLootSync.sendSync(null);
-				sender.addChatMessage(new ChatComponentText("Deleted all loot groups"));
-			} else
-			{
-				try
-				{
-					int idx = Integer.parseInt(args[1]);
-					if(LootRegistry.INSTANCE.removeID(idx))
-                    {
+                sender.addChatMessage(new ChatComponentText("Deleted all loot groups"));
+            } else {
+                try {
+                    int idx = Integer.parseInt(args[1]);
+                    if (LootRegistry.INSTANCE.removeID(idx)) {
                         NetLootSync.sendSync(null);
                         sender.addChatMessage(new ChatComponentText("Deleted loot group with ID " + idx));
-                    } else
-                    {
+                    } else {
                         sender.addChatMessage(new ChatComponentText("Unable to find loot group with ID " + idx));
                     }
-				} catch(Exception e)
-				{
-					throw new WrongUsageException(getCommandUsage(sender));
-				}
-			}
-		} else
-		{
-			throw new WrongUsageException(getCommandUsage(sender));
-		}
-	}
+                } catch (Exception e) {
+                    throw new WrongUsageException(getCommandUsage(sender));
+                }
+            }
+        } else {
+            throw new WrongUsageException(getCommandUsage(sender));
+        }
+    }
 }

--- a/src/main/java/bq_standard/core/BQS_Settings.java
+++ b/src/main/java/bq_standard/core/BQS_Settings.java
@@ -1,6 +1,5 @@
 package bq_standard.core;
 
-public class BQS_Settings
-{
-	public static boolean hideUpdates = false;
+public class BQS_Settings {
+    public static boolean hideUpdates = false;
 }

--- a/src/main/java/bq_standard/core/BQ_Standard.java
+++ b/src/main/java/bq_standard/core/BQ_Standard.java
@@ -22,75 +22,73 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.config.Configuration;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = BQ_Standard.MODID, name = BQ_Standard.NAME, version = BQ_Standard.VERSION, guiFactory = "bq_standard.handlers.ConfigGuiFactory")
-public class BQ_Standard
-{
+@Mod(
+        modid = BQ_Standard.MODID,
+        name = BQ_Standard.NAME,
+        version = BQ_Standard.VERSION,
+        guiFactory = "bq_standard.handlers.ConfigGuiFactory")
+public class BQ_Standard {
     public static final String MODID = "bq_standard";
     public static final String NAME = "Standard Expansion";
     public static final String VERSION = "GRADLETOKEN_VERSION";
     public static final String PROXY = "bq_standard.core.proxies";
     public static final String CHANNEL = "BQ_STANDARD";
-    
+
     public static boolean hasNEI = false;
-	
-	@Instance(MODID)
-	public static BQ_Standard instance;
-	
-	@SidedProxy(clientSide = PROXY + ".ClientProxy", serverSide = PROXY + ".CommonProxy")
-	public static CommonProxy proxy;
-	public SimpleNetworkWrapper network;
-	public static Logger logger;
-	
-	public static Item lootChest = new ItemLootChest();
-    
+
+    @Instance(MODID)
+    public static BQ_Standard instance;
+
+    @SidedProxy(clientSide = PROXY + ".ClientProxy", serverSide = PROXY + ".CommonProxy")
+    public static CommonProxy proxy;
+
+    public SimpleNetworkWrapper network;
+    public static Logger logger;
+
+    public static Item lootChest = new ItemLootChest();
+
     @EventHandler
-    public void preInit(FMLPreInitializationEvent event)
-    {
-    	logger = event.getModLog();
-    	network = NetworkRegistry.INSTANCE.newSimpleChannel(CHANNEL);
-    	
-    	ConfigHandler.config = new Configuration(event.getSuggestedConfigurationFile(), true);
-    	ConfigHandler.initConfigs();
-    	
-    	proxy.registerHandlers();
-    	
-    	NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
+    public void preInit(FMLPreInitializationEvent event) {
+        logger = event.getModLog();
+        network = NetworkRegistry.INSTANCE.newSimpleChannel(CHANNEL);
+
+        ConfigHandler.config = new Configuration(event.getSuggestedConfigurationFile(), true);
+        ConfigHandler.initConfigs();
+
+        proxy.registerHandlers();
+
+        NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
     }
-    
+
     @EventHandler
-    public void init(FMLInitializationEvent event)
-    {
-    	GameRegistry.registerItem(lootChest, "loot_chest");
-    	
-    	proxy.registerRenderers();
+    public void init(FMLInitializationEvent event) {
+        GameRegistry.registerItem(lootChest, "loot_chest");
+
+        proxy.registerRenderers();
     }
-    
+
     @EventHandler
-    public void postInit(FMLPostInitializationEvent event)
-    {
-        if(Loader.isModLoaded("betterquesting"))
-        {
+    public void postInit(FMLPostInitializationEvent event) {
+        if (Loader.isModLoaded("betterquesting")) {
             proxy.registerExpansion();
         }
-        
+
         hasNEI = Loader.isModLoaded("NotEnoughItems");
     }
-	
-	@EventHandler
-	public void serverStart(FMLServerStartingEvent event)
-	{
-		MinecraftServer server = event.getServer();
-		ICommandManager command = server.getCommandManager();
-		ServerCommandManager manager = (ServerCommandManager) command;
-		
-		manager.registerCommand(new BQS_Commands());
-		
-		LootSaveLoad.INSTANCE.LoadLoot(event.getServer());
-	}
-	
-	@EventHandler
-    public void serverStopped(FMLServerStoppedEvent event)
-    {
+
+    @EventHandler
+    public void serverStart(FMLServerStartingEvent event) {
+        MinecraftServer server = event.getServer();
+        ICommandManager command = server.getCommandManager();
+        ServerCommandManager manager = (ServerCommandManager) command;
+
+        manager.registerCommand(new BQS_Commands());
+
+        LootSaveLoad.INSTANCE.LoadLoot(event.getServer());
+    }
+
+    @EventHandler
+    public void serverStopped(FMLServerStoppedEvent event) {
         LootSaveLoad.INSTANCE.UnloadLoot();
     }
 }

--- a/src/main/java/bq_standard/core/proxies/ClientProxy.java
+++ b/src/main/java/bq_standard/core/proxies/ClientProxy.java
@@ -9,34 +9,30 @@ import bq_standard.importers.hqm.HQMBagImporter;
 import bq_standard.importers.hqm.HQMQuestImporter;
 import bq_standard.integration.nei.IMCForNEI;
 
-public class ClientProxy extends CommonProxy
-{
-	@Override
-	public boolean isClient()
-	{
-		return true;
-	}
-	
-	@Override
-	public void registerHandlers()
-	{
-		super.registerHandlers();
+public class ClientProxy extends CommonProxy {
+    @Override
+    public boolean isClient() {
+        return true;
+    }
 
-		IMCForNEI.IMCSender();
-	}
-	
-	@Override
-	public void registerExpansion()
-	{
-		super.registerExpansion();
-		
-		QuestingAPI.getAPI(ApiReference.IMPORT_REG).registerImporter(NativeFileImporter.INSTANCE);
-		
-		QuestingAPI.getAPI(ApiReference.IMPORT_REG).registerImporter(HQMQuestImporter.INSTANCE);
-		QuestingAPI.getAPI(ApiReference.IMPORT_REG).registerImporter(HQMBagImporter.INSTANCE);
-		
-		QuestingAPI.getAPI(ApiReference.IMPORT_REG).registerImporter(FTBQQuestImporter.INSTANCE);
-        
+    @Override
+    public void registerHandlers() {
+        super.registerHandlers();
+
+        IMCForNEI.IMCSender();
+    }
+
+    @Override
+    public void registerExpansion() {
+        super.registerExpansion();
+
+        QuestingAPI.getAPI(ApiReference.IMPORT_REG).registerImporter(NativeFileImporter.INSTANCE);
+
+        QuestingAPI.getAPI(ApiReference.IMPORT_REG).registerImporter(HQMQuestImporter.INSTANCE);
+        QuestingAPI.getAPI(ApiReference.IMPORT_REG).registerImporter(HQMBagImporter.INSTANCE);
+
+        QuestingAPI.getAPI(ApiReference.IMPORT_REG).registerImporter(FTBQQuestImporter.INSTANCE);
+
         BQSTextures.registerTextures();
-	}
+    }
 }

--- a/src/main/java/bq_standard/core/proxies/CommonProxy.java
+++ b/src/main/java/bq_standard/core/proxies/CommonProxy.java
@@ -16,58 +16,53 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
 
-public class CommonProxy
-{
-	public boolean isClient()
-	{
-		return false;
-	}
-	
-	public void registerHandlers()
-	{
-		MinecraftForge.EVENT_BUS.register(LootRegistry.INSTANCE);
-		EventHandler evHandle = new EventHandler();
-        FMLCommonHandler.instance().bus().register(evHandle);
-		MinecraftForge.EVENT_BUS.register(evHandle);
-	}
-	
-	public void registerRenderers()
-	{
-	}
-	
-	public void registerExpansion()
-	{
-		IRegistry<IFactoryData<ITask, NBTTagCompound>, ITask> taskReg = QuestingAPI.getAPI(ApiReference.TASK_REG);
-		taskReg.register(FactoryTaskBlockBreak.INSTANCE);
-		taskReg.register(FactoryTaskCheckbox.INSTANCE);
-		taskReg.register(FactoryTaskCrafting.INSTANCE);
-		taskReg.register(FactoryTaskFluid.INSTANCE);
-		taskReg.register(FactoryTaskHunt.INSTANCE);
-		taskReg.register(FactoryTaskLocation.INSTANCE);
-		taskReg.register(FactoryTaskMeeting.INSTANCE);
-		taskReg.register(FactoryTaskRetrieval.INSTANCE);
-		taskReg.register(FactoryTaskScoreboard.INSTANCE);
-		taskReg.register(FactoryTaskXP.INSTANCE);
-		taskReg.register(FactoryTaskInteractItem.INSTANCE);
-		taskReg.register(FactoryTaskInteractEntity.INSTANCE);
-		taskReg.register(FactoryTaskOptionalRetrieval.INSTANCE);
+public class CommonProxy {
+    public boolean isClient() {
+        return false;
+    }
 
-		IRegistry<IFactoryData<IReward, NBTTagCompound>, IReward> rewardReg = QuestingAPI.getAPI(ApiReference.REWARD_REG);
-		rewardReg.register(FactoryRewardChoice.INSTANCE);
-		rewardReg.register(FactoryRewardCommand.INSTANCE);
-		rewardReg.register(FactoryRewardItem.INSTANCE);
-		rewardReg.register(FactoryRewardScoreboard.INSTANCE);
-		rewardReg.register(FactoryRewardXP.INSTANCE);
-		rewardReg.register(FactoryRewardQuestCompletion.INSTANCE);
-		
-		NetLootSync.registerHandler();
-		NetLootClaim.registerHandler();
-		NetTaskCheckbox.registerHandler();
-		NetScoreSync.registerHandler();
-		NetRewardChoice.registerHandler();
-		NetLootImport.registerHandler();
-		NetTaskInteract.registerHandler();
-		
-		BQ_Standard.lootChest.setCreativeTab(QuestingAPI.getAPI(ApiReference.CREATIVE_TAB));
-	}
+    public void registerHandlers() {
+        MinecraftForge.EVENT_BUS.register(LootRegistry.INSTANCE);
+        EventHandler evHandle = new EventHandler();
+        FMLCommonHandler.instance().bus().register(evHandle);
+        MinecraftForge.EVENT_BUS.register(evHandle);
+    }
+
+    public void registerRenderers() {}
+
+    public void registerExpansion() {
+        IRegistry<IFactoryData<ITask, NBTTagCompound>, ITask> taskReg = QuestingAPI.getAPI(ApiReference.TASK_REG);
+        taskReg.register(FactoryTaskBlockBreak.INSTANCE);
+        taskReg.register(FactoryTaskCheckbox.INSTANCE);
+        taskReg.register(FactoryTaskCrafting.INSTANCE);
+        taskReg.register(FactoryTaskFluid.INSTANCE);
+        taskReg.register(FactoryTaskHunt.INSTANCE);
+        taskReg.register(FactoryTaskLocation.INSTANCE);
+        taskReg.register(FactoryTaskMeeting.INSTANCE);
+        taskReg.register(FactoryTaskRetrieval.INSTANCE);
+        taskReg.register(FactoryTaskScoreboard.INSTANCE);
+        taskReg.register(FactoryTaskXP.INSTANCE);
+        taskReg.register(FactoryTaskInteractItem.INSTANCE);
+        taskReg.register(FactoryTaskInteractEntity.INSTANCE);
+        taskReg.register(FactoryTaskOptionalRetrieval.INSTANCE);
+
+        IRegistry<IFactoryData<IReward, NBTTagCompound>, IReward> rewardReg =
+                QuestingAPI.getAPI(ApiReference.REWARD_REG);
+        rewardReg.register(FactoryRewardChoice.INSTANCE);
+        rewardReg.register(FactoryRewardCommand.INSTANCE);
+        rewardReg.register(FactoryRewardItem.INSTANCE);
+        rewardReg.register(FactoryRewardScoreboard.INSTANCE);
+        rewardReg.register(FactoryRewardXP.INSTANCE);
+        rewardReg.register(FactoryRewardQuestCompletion.INSTANCE);
+
+        NetLootSync.registerHandler();
+        NetLootClaim.registerHandler();
+        NetTaskCheckbox.registerHandler();
+        NetScoreSync.registerHandler();
+        NetRewardChoice.registerHandler();
+        NetLootImport.registerHandler();
+        NetTaskInteract.registerHandler();
+
+        BQ_Standard.lootChest.setCreativeTab(QuestingAPI.getAPI(ApiReference.CREATIVE_TAB));
+    }
 }

--- a/src/main/java/bq_standard/handlers/ConfigGuiFactory.java
+++ b/src/main/java/bq_standard/handlers/ConfigGuiFactory.java
@@ -2,34 +2,27 @@ package bq_standard.handlers;
 
 import bq_standard.client.gui.GuiBQSConfig;
 import cpw.mods.fml.client.IModGuiFactory;
+import java.util.Set;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 
-import java.util.Set;
-
-public class ConfigGuiFactory implements IModGuiFactory
-{
-	@Override
-	public void initialize(Minecraft minecraftInstance)
-	{
-	}
-    
+public class ConfigGuiFactory implements IModGuiFactory {
     @Override
-    public Class<? extends GuiScreen> mainConfigGuiClass()
-    {
+    public void initialize(Minecraft minecraftInstance) {}
+
+    @Override
+    public Class<? extends GuiScreen> mainConfigGuiClass() {
         return GuiBQSConfig.class;
     }
-    
+
     @Override
-	public Set<RuntimeOptionCategoryElement> runtimeGuiCategories()
-	{
-		return null;
-	}
-    
+    public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() {
+        return null;
+    }
+
     @Override
     @Deprecated
-    public RuntimeOptionGuiHandler getHandlerFor(RuntimeOptionCategoryElement element)
-    {
+    public RuntimeOptionGuiHandler getHandlerFor(RuntimeOptionCategoryElement element) {
         return null;
     }
 }

--- a/src/main/java/bq_standard/handlers/ConfigHandler.java
+++ b/src/main/java/bq_standard/handlers/ConfigHandler.java
@@ -5,24 +5,22 @@ import bq_standard.core.BQ_Standard;
 import net.minecraftforge.common.config.Configuration;
 import org.apache.logging.log4j.Level;
 
-public class ConfigHandler
-{
-	public static Configuration config;
-	
-	public static void initConfigs()
-	{
-		if(config == null)
-		{
-			BQ_Standard.logger.log(Level.ERROR, "Config attempted to be loaded before it was initialised!");
-			return;
-		}
-		
-		config.load();
-		
-		BQS_Settings.hideUpdates = config.getBoolean("Hide Updates", Configuration.CATEGORY_GENERAL, false, "Hide update notifications");
-		
-		config.save();
-		
-		BQ_Standard.logger.log(Level.INFO, "Loaded configs...");
-	}
+public class ConfigHandler {
+    public static Configuration config;
+
+    public static void initConfigs() {
+        if (config == null) {
+            BQ_Standard.logger.log(Level.ERROR, "Config attempted to be loaded before it was initialised!");
+            return;
+        }
+
+        config.load();
+
+        BQS_Settings.hideUpdates =
+                config.getBoolean("Hide Updates", Configuration.CATEGORY_GENERAL, false, "Hide update notifications");
+
+        config.save();
+
+        BQ_Standard.logger.log(Level.INFO, "Loaded configs...");
+    }
 }

--- a/src/main/java/bq_standard/handlers/EventHandler.java
+++ b/src/main/java/bq_standard/handlers/EventHandler.java
@@ -21,6 +21,11 @@ import cpw.mods.fml.common.gameevent.PlayerEvent.ItemSmeltedEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+import java.util.function.IntSupplier;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -39,230 +44,233 @@ import net.minecraftforge.event.world.BlockEvent.BreakEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import org.apache.commons.lang3.Validate;
 
-import java.util.ArrayDeque;
-import java.util.HashSet;
-import java.util.concurrent.Callable;
-import java.util.concurrent.FutureTask;
-import java.util.function.IntSupplier;
-
 @SuppressWarnings("unused")
-public class EventHandler
-{
+public class EventHandler {
     @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onPlayerInteract(PlayerInteractEvent event)
-    {
-        if(event.entityPlayer == null || event.entityPlayer instanceof FakePlayer || event.entityPlayer.worldObj.isRemote || event.isCanceled()) return;
-        
-		EntityPlayer player = event.entityPlayer;
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        if (event.entityPlayer == null
+                || event.entityPlayer instanceof FakePlayer
+                || event.entityPlayer.worldObj.isRemote
+                || event.isCanceled()) return;
+
+        EntityPlayer player = event.entityPlayer;
         ParticipantInfo pInfo = new ParticipantInfo(player);
-		
-		Block block = player.worldObj.getBlock(event.x, event.y, event.z);
-		int meta = player.worldObj.getBlockMetadata(event.x, event.y, event.z);
-		boolean isHit = event.action == Action.LEFT_CLICK_BLOCK;
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskInteractItem) ((TaskInteractItem)task.getValue()).onInteract(pInfo, entry, player.getHeldItem(), block, meta, event.x, event.y, event.z, isHit);
+
+        Block block = player.worldObj.getBlock(event.x, event.y, event.z);
+        int meta = player.worldObj.getBlockMetadata(event.x, event.y, event.z);
+        boolean isHit = event.action == Action.LEFT_CLICK_BLOCK;
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskInteractItem)
+                    ((TaskInteractItem) task.getValue())
+                            .onInteract(
+                                    pInfo, entry, player.getHeldItem(), block, meta, event.x, event.y, event.z, isHit);
             }
-		}
+        }
     }
-    
+
     @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onEntityAttack(AttackEntityEvent event)
-    {
-        if(event.entityPlayer == null || event.entityPlayer instanceof FakePlayer || event.target == null || event.entityPlayer.worldObj.isRemote || event.isCanceled()) return;
-        
-		EntityPlayer player = event.entityPlayer;
+    public void onEntityAttack(AttackEntityEvent event) {
+        if (event.entityPlayer == null
+                || event.entityPlayer instanceof FakePlayer
+                || event.target == null
+                || event.entityPlayer.worldObj.isRemote
+                || event.isCanceled()) return;
+
+        EntityPlayer player = event.entityPlayer;
         ParticipantInfo pInfo = new ParticipantInfo(player);
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskInteractEntity) ((TaskInteractEntity)task.getValue()).onInteract(pInfo, entry, player.getHeldItem(), event.target, true);
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskInteractEntity)
+                    ((TaskInteractEntity) task.getValue())
+                            .onInteract(pInfo, entry, player.getHeldItem(), event.target, true);
             }
-		}
+        }
     }
-    
+
     @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onEntityInteract(EntityInteractEvent event)
-    {
-        if(event.entityPlayer == null || event.entityPlayer instanceof FakePlayer || event.target == null || event.entityPlayer.worldObj.isRemote || event.isCanceled()) return;
-        
-		EntityPlayer player = event.entityPlayer;
+    public void onEntityInteract(EntityInteractEvent event) {
+        if (event.entityPlayer == null
+                || event.entityPlayer instanceof FakePlayer
+                || event.target == null
+                || event.entityPlayer.worldObj.isRemote
+                || event.isCanceled()) return;
+
+        EntityPlayer player = event.entityPlayer;
         ParticipantInfo pInfo = new ParticipantInfo(player);
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskInteractEntity) ((TaskInteractEntity)task.getValue()).onInteract(pInfo, entry, player.getHeldItem(), event.target, false);
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskInteractEntity)
+                    ((TaskInteractEntity) task.getValue())
+                            .onInteract(pInfo, entry, player.getHeldItem(), event.target, false);
             }
-		}
+        }
     }
-    
-	@SubscribeEvent(priority = EventPriority.LOWEST)
-	public void onItemCrafted(ItemCraftedEvent event)
-	{
-		if(event.player == null || event.player instanceof FakePlayer || event.player.worldObj.isRemote) return;
-        
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onItemCrafted(ItemCraftedEvent event) {
+        if (event.player == null || event.player instanceof FakePlayer || event.player.worldObj.isRemote) return;
+
         ParticipantInfo pInfo = new ParticipantInfo(event.player);
 
         IntSupplier realStackSizeSupplier = null;
-        if(event.craftMatrix instanceof InventoryCrafting && event.crafting.stackSize == 0) // Hack for broken-ass shift clicking reporting empty stacks
+        if (event.craftMatrix instanceof InventoryCrafting
+                && event.crafting.stackSize == 0) // Hack for broken-ass shift clicking reporting empty stacks
         {
             realStackSizeSupplier = new IntSupplier() {
                 private int stackSize = -1;
+
                 private int get() {
-                    ItemStack result = CraftingManager.getInstance().findMatchingRecipe((InventoryCrafting) event.craftMatrix, event.player.worldObj);
+                    ItemStack result = CraftingManager.getInstance()
+                            .findMatchingRecipe((InventoryCrafting) event.craftMatrix, event.player.worldObj);
                     return result != null ? result.stackSize : event.crafting.stackSize;
                 }
+
                 @Override
                 public int getAsInt() {
-                    if (stackSize < 0)
-                        stackSize = get();
+                    if (stackSize < 0) stackSize = get();
                     return stackSize;
                 }
             };
         }
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskCrafting) ((TaskCrafting)task.getValue()).onItemCraft(pInfo, entry, event.crafting, realStackSizeSupplier);
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskCrafting)
+                    ((TaskCrafting) task.getValue()).onItemCraft(pInfo, entry, event.crafting, realStackSizeSupplier);
             }
-		}
-	}
-	
-	@SubscribeEvent(priority = EventPriority.LOWEST)
-	public void onItemSmelted(ItemSmeltedEvent event) // This event is even more busted than crafting when shift clicking (only ever reports 2 empty stacks regardless of actual amount)
-	{
-		if(event.player == null || event.player instanceof FakePlayer || event.player.worldObj.isRemote) return;
-		
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onItemSmelted(
+            ItemSmeltedEvent
+                    event) // This event is even more busted than crafting when shift clicking (only ever reports 2
+                // empty stacks regardless of actual amount)
+            {
+        if (event.player == null || event.player instanceof FakePlayer || event.player.worldObj.isRemote) return;
+
         ParticipantInfo pInfo = new ParticipantInfo(event.player);
-		
-		ItemStack refStack = event.smelting.copy();
-		if(refStack.stackSize <= 0) refStack.stackSize = 1; // Doesn't really fix much but it's better than nothing I suppose
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskCrafting) ((TaskCrafting)task.getValue()).onItemSmelt(pInfo, entry, refStack);
+
+        ItemStack refStack = event.smelting.copy();
+        if (refStack.stackSize <= 0)
+            refStack.stackSize = 1; // Doesn't really fix much but it's better than nothing I suppose
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskCrafting)
+                    ((TaskCrafting) task.getValue()).onItemSmelt(pInfo, entry, refStack);
             }
-		}
-	}
-	
-	@SubscribeEvent(priority = EventPriority.LOWEST)
-	public void onItemAnvil(AnvilRepairEvent event) // Somehow actually works as intended unlike other crafting methods
-	{
-		if(event.entityPlayer == null || event.entityPlayer instanceof FakePlayer || event.entityPlayer.worldObj.isRemote) return;
-        
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onItemAnvil(AnvilRepairEvent event) // Somehow actually works as intended unlike other crafting methods
+            {
+        if (event.entityPlayer == null
+                || event.entityPlayer instanceof FakePlayer
+                || event.entityPlayer.worldObj.isRemote) return;
+
         ParticipantInfo pInfo = new ParticipantInfo(event.entityPlayer);
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskCrafting) ((TaskCrafting)task.getValue()).onItemAnvil(pInfo, entry, event.output.copy());
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskCrafting)
+                    ((TaskCrafting) task.getValue()).onItemAnvil(pInfo, entry, event.output.copy());
             }
-		}
-	}
-	
-	@SubscribeEvent(priority = EventPriority.LOWEST)
-	public void onEntityKilled(LivingDeathEvent event)
-	{
-		if(event.source == null || !(event.source.getEntity() instanceof EntityPlayer) || event.source.getEntity() instanceof FakePlayer || event.source.getEntity().worldObj.isRemote || event.isCanceled()) return;
-		
-		EntityPlayer player = (EntityPlayer)event.source.getEntity();
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onEntityKilled(LivingDeathEvent event) {
+        if (event.source == null
+                || !(event.source.getEntity() instanceof EntityPlayer)
+                || event.source.getEntity() instanceof FakePlayer
+                || event.source.getEntity().worldObj.isRemote
+                || event.isCanceled()) return;
+
+        EntityPlayer player = (EntityPlayer) event.source.getEntity();
         ParticipantInfo pInfo = new ParticipantInfo(player);
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskHunt) ((TaskHunt)task.getValue()).onKilledByPlayer(pInfo, entry, event.entityLiving, event.source);
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskHunt)
+                    ((TaskHunt) task.getValue()).onKilledByPlayer(pInfo, entry, event.entityLiving, event.source);
             }
-		}
-	}
-	
-	@SubscribeEvent(priority = EventPriority.LOWEST)
-	public void onBlockBreak(BreakEvent event)
-	{
-		if(event.getPlayer() == null || event.getPlayer() instanceof FakePlayer || event.getPlayer().worldObj.isRemote || event.isCanceled()) return;
-		
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onBlockBreak(BreakEvent event) {
+        if (event.getPlayer() == null
+                || event.getPlayer() instanceof FakePlayer
+                || event.getPlayer().worldObj.isRemote
+                || event.isCanceled()) return;
+
         ParticipantInfo pInfo = new ParticipantInfo(event.getPlayer());
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskBlockBreak) ((TaskBlockBreak)task.getValue()).onBlockBreak(pInfo, entry, event.block, event.blockMetadata, event.x, event.y, event.z);
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskBlockBreak)
+                    ((TaskBlockBreak) task.getValue())
+                            .onBlockBreak(pInfo, entry, event.block, event.blockMetadata, event.x, event.y, event.z);
             }
-		}
-	}
-	
-	@SubscribeEvent
-    public void onEntityLiving(BQLivingUpdateEvent event)
-    {
-        if(!(event.entityLiving instanceof EntityPlayer) || event.entityLiving.worldObj.isRemote || event.entityLiving.ticksExisted%20 != 0 || QuestingAPI.getAPI(ApiReference.SETTINGS).getProperty(NativeProps.EDIT_MODE)) return;
-        
-        EntityPlayer player = (EntityPlayer)event.entityLiving;
+        }
+    }
+
+    @SubscribeEvent
+    public void onEntityLiving(BQLivingUpdateEvent event) {
+        if (!(event.entityLiving instanceof EntityPlayer)
+                || event.entityLiving.worldObj.isRemote
+                || event.entityLiving.ticksExisted % 20 != 0
+                || QuestingAPI.getAPI(ApiReference.SETTINGS).getProperty(NativeProps.EDIT_MODE)) return;
+
+        EntityPlayer player = (EntityPlayer) event.entityLiving;
         ParticipantInfo pInfo = new ParticipantInfo(player);
-		
-		for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof ITaskTickable)
-                {
-                    ((ITaskTickable)task.getValue()).tickTask(pInfo, entry);
+
+        for (DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof ITaskTickable) {
+                    ((ITaskTickable) task.getValue()).tickTask(pInfo, entry);
                 }
             }
-		}
+        }
     }
-    
+
     @SubscribeEvent
-    public void onEntityCreated(EntityJoinWorldEvent event)
-    {
-        if(!(event.entity instanceof EntityPlayer) || event.entity.worldObj.isRemote) return;
-        
-		PlayerContainerListener.refreshListener((EntityPlayer)event.entity);
+    public void onEntityCreated(EntityJoinWorldEvent event) {
+        if (!(event.entity instanceof EntityPlayer) || event.entity.worldObj.isRemote) return;
+
+        PlayerContainerListener.refreshListener((EntityPlayer) event.entity);
     }
-	
-	@SubscribeEvent
-	public void onConfigChanged(ConfigChangedEvent event)
-	{
-		if(event.modID.equalsIgnoreCase(BQ_Standard.MODID))
-		{
-			ConfigHandler.config.save();
-			ConfigHandler.initConfigs();
-		}
-	}
-	
-	@SubscribeEvent
-    public void onPlayerJoin(PlayerLoggedInEvent event)
-    {
-		if(!event.player.worldObj.isRemote && event.player instanceof EntityPlayerMP)
-		{
-            NetLootSync.sendSync((EntityPlayerMP)event.player);
-		}
+
+    @SubscribeEvent
+    public void onConfigChanged(ConfigChangedEvent event) {
+        if (event.modID.equalsIgnoreCase(BQ_Standard.MODID)) {
+            ConfigHandler.config.save();
+            ConfigHandler.initConfigs();
+        }
     }
-	
-	@SubscribeEvent
-    public void onWorldSave(WorldEvent.Save event)
-    {
-        if(!event.world.isRemote && LootSaveLoad.INSTANCE.worldDir != null && event.world.provider.dimensionId == 0)
-        {
+
+    @SubscribeEvent
+    public void onPlayerJoin(PlayerLoggedInEvent event) {
+        if (!event.player.worldObj.isRemote && event.player instanceof EntityPlayerMP) {
+            NetLootSync.sendSync((EntityPlayerMP) event.player);
+        }
+    }
+
+    @SubscribeEvent
+    public void onWorldSave(WorldEvent.Save event) {
+        if (!event.world.isRemote && LootSaveLoad.INSTANCE.worldDir != null && event.world.provider.dimensionId == 0) {
             LootSaveLoad.INSTANCE.SaveLoot();
         }
     }
-	
-	private static final ArrayDeque<FutureTask> serverTasks = new ArrayDeque<>();
-	private static Thread serverThread = null;
+
+    private static final ArrayDeque<FutureTask> serverTasks = new ArrayDeque<>();
+    private static Thread serverThread = null;
 
     private static HashSet<EntityPlayer> playerInventoryUpdates = new HashSet<>();
 
@@ -275,30 +283,27 @@ public class EventHandler
             playerInventoryUpdates.add(player);
         }
     }
-	
-	// NOTE: This is slightly different to the version in the base mod. This one will not immediately run tasks even if it's from the same thread.
-    public static <T> ListenableFuture<T> scheduleServerTask(Callable<T> task)
-    {
+
+    // NOTE: This is slightly different to the version in the base mod. This one will not immediately run tasks even if
+    // it's from the same thread.
+    public static <T> ListenableFuture<T> scheduleServerTask(Callable<T> task) {
         Validate.notNull(task);
-        
+
         ListenableFutureTask<T> listenablefuturetask = ListenableFutureTask.create(task);
 
-        synchronized (serverTasks)
-        {
+        synchronized (serverTasks) {
             serverTasks.add(listenablefuturetask);
             return listenablefuturetask;
         }
     }
-	
-	@SubscribeEvent
-    public void onServerTick(ServerTickEvent event)
-    {
-        if(event.phase != Phase.START) return;
-        if(serverThread == null) serverThread = Thread.currentThread();
-        
-        synchronized(serverTasks)
-        {
-            while(!serverTasks.isEmpty()) serverTasks.poll().run();
+
+    @SubscribeEvent
+    public void onServerTick(ServerTickEvent event) {
+        if (event.phase != Phase.START) return;
+        if (serverThread == null) serverThread = Thread.currentThread();
+
+        synchronized (serverTasks) {
+            while (!serverTasks.isEmpty()) serverTasks.poll().run();
         }
 
         synchronized (playerInventoryUpdates) {
@@ -308,11 +313,11 @@ public class EventHandler
                 }
                 ParticipantInfo pInfo = new ParticipantInfo(player);
 
-                for(DBEntry<IQuest> entry : QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests()))
-                {
-                    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-                    {
-                        if(task.getValue() instanceof ITaskInventory) ((ITaskInventory)task.getValue()).onInventoryChange(entry, pInfo);
+                for (DBEntry<IQuest> entry :
+                        QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests())) {
+                    for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                        if (task.getValue() instanceof ITaskInventory)
+                            ((ITaskInventory) task.getValue()).onInventoryChange(entry, pInfo);
                     }
                 }
             }

--- a/src/main/java/bq_standard/handlers/GuiHandler.java
+++ b/src/main/java/bq_standard/handlers/GuiHandler.java
@@ -5,22 +5,18 @@ import cpw.mods.fml.common.network.IGuiHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 
-public class GuiHandler implements IGuiHandler
-{
-	@Override
-	public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z)
-	{
-		return null;
-	}
-	
-	@Override
-	public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z)
-	{
-		if(ID == 0)
-		{
+public class GuiHandler implements IGuiHandler {
+    @Override
+    public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
+        return null;
+    }
+
+    @Override
+    public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
+        if (ID == 0) {
             return new GuiEditLootGroup(null);
-		}
-		
-		return null;
-	}
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/bq_standard/handlers/LootSaveLoad.java
+++ b/src/main/java/bq_standard/handlers/LootSaveLoad.java
@@ -5,53 +5,46 @@ import betterquesting.api.utils.NBTConverter;
 import bq_standard.core.BQ_Standard;
 import bq_standard.rewards.loot.LootRegistry;
 import com.google.gson.JsonObject;
+import java.io.File;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 
-import java.io.File;
-
-public class LootSaveLoad
-{
+public class LootSaveLoad {
     public static LootSaveLoad INSTANCE = new LootSaveLoad();
-    
+
     public File worldDir;
-    
-    public void LoadLoot(MinecraftServer server)
-    {
-        if(BQ_Standard.proxy.isClient())
-		{
-			worldDir = server.getFile("saves/" + server.getFolderName());
-		} else
-		{
-			worldDir = server.getFile(server.getFolderName());
-		}
-    	
-    	File f1 = new File(worldDir, "QuestLoot.json");
-		JsonObject j1 = new JsonObject();
-		
-		if(f1.exists())
-		{
-			j1 = JsonHelper.ReadFromFile(f1);
-		} else
-		{
-			f1 = server.getFile("config/betterquesting/DefaultLoot.json");
-			
-			if(f1.exists())
-			{
-				j1 = JsonHelper.ReadFromFile(f1);
-			}
-		}
-		
-		LootRegistry.INSTANCE.readFromNBT(NBTConverter.JSONtoNBT_Object(j1, new NBTTagCompound(), true), false);
+
+    public void LoadLoot(MinecraftServer server) {
+        if (BQ_Standard.proxy.isClient()) {
+            worldDir = server.getFile("saves/" + server.getFolderName());
+        } else {
+            worldDir = server.getFile(server.getFolderName());
+        }
+
+        File f1 = new File(worldDir, "QuestLoot.json");
+        JsonObject j1 = new JsonObject();
+
+        if (f1.exists()) {
+            j1 = JsonHelper.ReadFromFile(f1);
+        } else {
+            f1 = server.getFile("config/betterquesting/DefaultLoot.json");
+
+            if (f1.exists()) {
+                j1 = JsonHelper.ReadFromFile(f1);
+            }
+        }
+
+        LootRegistry.INSTANCE.readFromNBT(NBTConverter.JSONtoNBT_Object(j1, new NBTTagCompound(), true), false);
     }
-    
-    public void SaveLoot()
-    {
-        JsonHelper.WriteToFile(new File(worldDir, "QuestLoot.json"), NBTConverter.NBTtoJSON_Compound(LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null), new JsonObject(), true));
+
+    public void SaveLoot() {
+        JsonHelper.WriteToFile(
+                new File(worldDir, "QuestLoot.json"),
+                NBTConverter.NBTtoJSON_Compound(
+                        LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null), new JsonObject(), true));
     }
-    
-    public void UnloadLoot()
-    {
+
+    public void UnloadLoot() {
         LootRegistry.INSTANCE.reset();
         LootRegistry.INSTANCE.updateUI = false;
         worldDir = null;

--- a/src/main/java/bq_standard/handlers/PlayerContainerListener.java
+++ b/src/main/java/bq_standard/handlers/PlayerContainerListener.java
@@ -1,69 +1,54 @@
 package bq_standard.handlers;
 
-import betterquesting.api.api.ApiReference;
 import betterquesting.api.api.QuestingAPI;
-import betterquesting.api.questing.IQuest;
-import betterquesting.api.questing.tasks.ITask;
-import betterquesting.api2.storage.DBEntry;
-import betterquesting.api2.utils.ParticipantInfo;
-import bq_standard.tasks.ITaskInventory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nonnull;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
-
-public class PlayerContainerListener implements ICrafting
-{
+public class PlayerContainerListener implements ICrafting {
     private static final HashMap<UUID, PlayerContainerListener> LISTEN_MAP = new HashMap<>();
-    
-    static void refreshListener(@Nonnull EntityPlayer player)
-    {
+
+    static void refreshListener(@Nonnull EntityPlayer player) {
         UUID uuid = QuestingAPI.getQuestingUUID(player);
         PlayerContainerListener listener = LISTEN_MAP.get(uuid);
-        if(listener != null)
-        {
+        if (listener != null) {
             listener.player = player;
-        } else
-        {
+        } else {
             listener = new PlayerContainerListener(player);
             LISTEN_MAP.put(uuid, listener);
         }
-        
-        try
-        {
+
+        try {
             player.inventoryContainer.addCraftingToCrafters(listener);
-        } catch(Exception ignored){}
+        } catch (Exception ignored) {
+        }
     }
-    
+
     private EntityPlayer player;
-    
-    private PlayerContainerListener(@Nonnull EntityPlayer player)
-    {
+
+    private PlayerContainerListener(@Nonnull EntityPlayer player) {
         this.player = player;
     }
-    
+
     @Override
-    public void sendContainerAndContentsToPlayer(Container container, List nonNullList)
-    {
+    public void sendContainerAndContentsToPlayer(Container container, List nonNullList) {
         updateTasks();
     }
-    
+
     @Override
-    public void sendSlotContents(Container container, int i, ItemStack itemStack)
-    {
+    public void sendSlotContents(Container container, int i, ItemStack itemStack) {
         updateTasks();
     }
-    
+
     @Override
-    public void sendProgressBarUpdate(Container container, int i, int i1){}
-    
-    private void updateTasks()
-    {
+    public void sendProgressBarUpdate(Container container, int i, int i1) {}
+
+    private void updateTasks() {
         EventHandler.schedulePlayerInventoryCheck(player);
     }
 }

--- a/src/main/java/bq_standard/importers/NativeFileImporter.java
+++ b/src/main/java/bq_standard/importers/NativeFileImporter.java
@@ -8,108 +8,93 @@ import betterquesting.api.questing.IQuestLineDatabase;
 import betterquesting.api.utils.FileExtensionFilter;
 import betterquesting.api.utils.JsonHelper;
 import betterquesting.api.utils.NBTConverter;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 
-public class NativeFileImporter implements IImporter
-{
-	public static final NativeFileImporter INSTANCE = new NativeFileImporter();
-	private static final FileFilter FILTER = new FileExtensionFilter(".json");
-	
-	@Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.importer.nat_file.name";
-	}
-	
-	@Override
-	public String getUnlocalisedDescription()
-	{
-		return "bq_standard.importer.nat_file.desc";
-	}
-	
-	@Override
-	public FileFilter getFileFilter()
-	{
-		return FILTER;
-	}
+public class NativeFileImporter implements IImporter {
+    public static final NativeFileImporter INSTANCE = new NativeFileImporter();
+    private static final FileFilter FILTER = new FileExtensionFilter(".json");
 
-	@Override
-	public void loadFiles(IQuestDatabase questDB, IQuestLineDatabase lineDB, File[] files)
-	{
-		for(File selected : files)
-		{
-			if(selected == null || !selected.exists()) continue;
-			
-			NBTTagCompound nbt = NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(selected), new NBTTagCompound(), true);
-			HashMap<Integer, Integer> remappedIDs = readQuests(nbt.getTagList("questDatabase", 10), questDB);
-			readQuestLines(nbt.getTagList("questLines", 10), lineDB, remappedIDs);
-		}
-	}
-	
-	private HashMap<Integer,Integer> readQuests(NBTTagList json, IQuestDatabase questDB)
-    {
-        HashMap<Integer,Integer> remappedIDs = new HashMap<>();
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.importer.nat_file.name";
+    }
+
+    @Override
+    public String getUnlocalisedDescription() {
+        return "bq_standard.importer.nat_file.desc";
+    }
+
+    @Override
+    public FileFilter getFileFilter() {
+        return FILTER;
+    }
+
+    @Override
+    public void loadFiles(IQuestDatabase questDB, IQuestLineDatabase lineDB, File[] files) {
+        for (File selected : files) {
+            if (selected == null || !selected.exists()) continue;
+
+            NBTTagCompound nbt =
+                    NBTConverter.JSONtoNBT_Object(JsonHelper.ReadFromFile(selected), new NBTTagCompound(), true);
+            HashMap<Integer, Integer> remappedIDs = readQuests(nbt.getTagList("questDatabase", 10), questDB);
+            readQuestLines(nbt.getTagList("questLines", 10), lineDB, remappedIDs);
+        }
+    }
+
+    private HashMap<Integer, Integer> readQuests(NBTTagList json, IQuestDatabase questDB) {
+        HashMap<Integer, Integer> remappedIDs = new HashMap<>();
         List<IQuest> loadedQuests = new ArrayList<>();
-        
-        for(int i = 0; i < json.tagCount(); i++)
-		{
-		    NBTTagCompound qTag = json.getCompoundTagAt(i);
-		    int oldID = qTag.hasKey("questID", 99) ? qTag.getInteger("questID") : -1;
-		    if(oldID < 0) continue;
-		    
-            
-			int qID = questDB.nextID();
-			IQuest quest = questDB.createNew(qID);
-			quest.readFromNBT(qTag);
-			remappedIDs.put(oldID, qID);
-			loadedQuests.add(quest);
-		}
-		
-		for(IQuest quest : loadedQuests)
-        {
+
+        for (int i = 0; i < json.tagCount(); i++) {
+            NBTTagCompound qTag = json.getCompoundTagAt(i);
+            int oldID = qTag.hasKey("questID", 99) ? qTag.getInteger("questID") : -1;
+            if (oldID < 0) continue;
+
+            int qID = questDB.nextID();
+            IQuest quest = questDB.createNew(qID);
+            quest.readFromNBT(qTag);
+            remappedIDs.put(oldID, qID);
+            loadedQuests.add(quest);
+        }
+
+        for (IQuest quest : loadedQuests) {
             int[] oldIDs = Arrays.copyOf(quest.getRequirements(), quest.getRequirements().length);
-            
-            for(int n = 0; n < oldIDs.length; n++)
-            {
-                if(remappedIDs.containsKey(oldIDs[n])) oldIDs[n] = remappedIDs.get(oldIDs[n]);
+
+            for (int n = 0; n < oldIDs.length; n++) {
+                if (remappedIDs.containsKey(oldIDs[n])) oldIDs[n] = remappedIDs.get(oldIDs[n]);
             }
-            
+
             quest.setRequirements(oldIDs);
         }
-        
+
         return remappedIDs;
     }
-    
-    private void readQuestLines(NBTTagList json, IQuestLineDatabase lineDB, HashMap<Integer, Integer> remappeIDs)
-    {
-        for(int i = 0; i < json.tagCount(); i++)
-		{
-			NBTTagCompound jql = (NBTTagCompound)json.getCompoundTagAt(i).copy();
-			
-			if(jql.hasKey("quests", 9))
-            {
+
+    private void readQuestLines(NBTTagList json, IQuestLineDatabase lineDB, HashMap<Integer, Integer> remappeIDs) {
+        for (int i = 0; i < json.tagCount(); i++) {
+            NBTTagCompound jql = (NBTTagCompound) json.getCompoundTagAt(i).copy();
+
+            if (jql.hasKey("quests", 9)) {
                 NBTTagList qList = jql.getTagList("quests", 10);
-                for(int n = 0; n < qList.tagCount(); n++)
-                {
-			        NBTTagCompound qTag = qList.getCompoundTagAt(n);
-                    
+                for (int n = 0; n < qList.tagCount(); n++) {
+                    NBTTagCompound qTag = qList.getCompoundTagAt(n);
+
                     int oldID = qTag.hasKey("id", 99) ? qTag.getInteger("id") : -1;
-                    if(oldID < 0) continue;
+                    if (oldID < 0) continue;
                     Integer qID = remappeIDs.get(oldID);
                     qTag.setInteger("id", qID);
                 }
             }
-			
-			IQuestLine ql = lineDB.createNew(lineDB.nextID());
-			ql.readFromNBT(jql);
-		}
+
+            IQuestLine ql = lineDB.createNew(lineDB.nextID());
+            ql.readFromNBT(jql);
+        }
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/FTBEntry.java
+++ b/src/main/java/bq_standard/importers/ftbq/FTBEntry.java
@@ -1,20 +1,17 @@
 package bq_standard.importers.ftbq;
 
-public class FTBEntry
-{
+public class FTBEntry {
     public final int id;
     public final Object obj;
     public final FTBEntryType type;
-    
-    public FTBEntry(int id, Object obj, FTBEntryType type)
-    {
+
+    public FTBEntry(int id, Object obj, FTBEntryType type) {
         this.id = id;
         this.obj = obj;
         this.type = type;
     }
-    
-    public enum FTBEntryType
-    {
+
+    public enum FTBEntryType {
         QUEST,
         LINE,
         VAR

--- a/src/main/java/bq_standard/importers/ftbq/FTBQFileFIlter.java
+++ b/src/main/java/bq_standard/importers/ftbq/FTBQFileFIlter.java
@@ -3,11 +3,9 @@ package bq_standard.importers.ftbq;
 import java.io.File;
 import java.io.FileFilter;
 
-public class FTBQFileFIlter implements FileFilter
-{
+public class FTBQFileFIlter implements FileFilter {
     @Override
-    public boolean accept(File pathname)
-    {
+    public boolean accept(File pathname) {
         return pathname != null && (pathname.isDirectory() || pathname.getName().equalsIgnoreCase("index.nbt"));
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/FTBQQuestImporter.java
+++ b/src/main/java/bq_standard/importers/ftbq/FTBQQuestImporter.java
@@ -16,10 +16,6 @@ import bq_standard.importers.ftbq.converters.rewards.FtbqRewardItem;
 import bq_standard.importers.ftbq.converters.rewards.FtbqRewardXP;
 import bq_standard.importers.ftbq.converters.tasks.*;
 import bq_standard.tasks.TaskCheckbox;
-import net.minecraft.nbt.CompressedStreamTools;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
@@ -28,243 +24,221 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.Function;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 
-public class FTBQQuestImporter implements IImporter
-{
+public class FTBQQuestImporter implements IImporter {
     public static final FTBQQuestImporter INSTANCE = new FTBQQuestImporter();
     private static final FileFilter FILTER = new FTBQFileFIlter();
-    
+
     private static final HashMap<String, Function<NBTTagCompound, ITask[]>> taskConverters = new HashMap<>();
     private static final HashMap<String, Function<NBTTagCompound, IReward[]>> rewardConverters = new HashMap<>();
-    
+
     @Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.importer.ftbq_quest.name";
-	}
- 
-	@Override
-	public String getUnlocalisedDescription()
-	{
-		return "bq_standard.importer.ftbq_quest.desc";
-	}
-    
+    public String getUnlocalisedName() {
+        return "bq_standard.importer.ftbq_quest.name";
+    }
+
     @Override
-    public FileFilter getFileFilter()
-    {
+    public String getUnlocalisedDescription() {
+        return "bq_standard.importer.ftbq_quest.desc";
+    }
+
+    @Override
+    public FileFilter getFileFilter() {
         return FILTER;
     }
-    
+
     @Override
-    public void loadFiles(IQuestDatabase questDB, IQuestLineDatabase lineDB, File[] files)
-    {
-        for(File f : files)
-        {
-            if(f == null || f.getParent() == null) continue;
-            
-            try(FileInputStream fis = new FileInputStream(f))
-            {
+    public void loadFiles(IQuestDatabase questDB, IQuestLineDatabase lineDB, File[] files) {
+        for (File f : files) {
+            if (f == null || f.getParent() == null) continue;
+
+            try (FileInputStream fis = new FileInputStream(f)) {
                 startImport(questDB, lineDB, CompressedStreamTools.readCompressed(fis), f.getParentFile());
-            } catch(Exception e)
-            {
-                BQ_Standard.logger.error("Failed to import FTB Quests NBT file:\n" + f.getAbsolutePath() + "\nReason:", e);
+            } catch (Exception e) {
+                BQ_Standard.logger.error(
+                        "Failed to import FTB Quests NBT file:\n" + f.getAbsolutePath() + "\nReason:", e);
             }
         }
     }
-    
+
     // NOTE: FTBQ shares IDs between multiple object types (WHY?!). Check type before use
     private final HashMap<String, FTBEntry> ID_MAP = new HashMap<>();
-    
-    private void startImport(IQuestDatabase questDB, IQuestLineDatabase lineDB, NBTTagCompound tagIndex, File folder)
-    {
+
+    private void startImport(IQuestDatabase questDB, IQuestLineDatabase lineDB, NBTTagCompound tagIndex, File folder) {
         int[] indexIDs = tagIndex.getIntArray("index"); // Read out the chapter index names
         ID_MAP.clear();
         requestIcon(null);
-        
+
         HashMap<IQuest, String[]> parentMap = new HashMap<>();
-        
+
         BQ_Standard.logger.info("Found " + indexIDs.length + " quest chapter(s) to import");
-        for(int id : indexIDs)
-        {
+        for (int id : indexIDs) {
             String hexName = String.format("%1$08x", id);
-            
+
             File qlFolder = new File(folder, hexName);
-            if(!qlFolder.exists() || !qlFolder.isDirectory()) continue;
+            if (!qlFolder.exists() || !qlFolder.isDirectory()) continue;
             File[] contents = qlFolder.listFiles();
-            if(contents == null) continue;
-            
+            if (contents == null) continue;
+
             int lineID = lineDB.nextID();
             IQuestLine questLine = lineDB.createNew(lineID);
             ID_MAP.put(hexName, new FTBEntry(lineID, questLine, FTBEntryType.LINE));
 
-            for(File questFile : contents)
-            {
-                if(!questFile.getName().toLowerCase().endsWith(".nbt")) continue; // No idea why this file is in here
-                
+            for (File questFile : contents) {
+                if (!questFile.getName().toLowerCase().endsWith(".nbt")) continue; // No idea why this file is in here
+
                 NBTTagCompound qTag; // Read NBT file
-                try(FileInputStream chFis = new FileInputStream(questFile))
-                {
+                try (FileInputStream chFis = new FileInputStream(questFile)) {
                     qTag = CompressedStreamTools.readCompressed(chFis);
-                } catch(Exception e)
-                {
+                } catch (Exception e) {
                     BQ_Standard.logger.error("Failed to import chapter file entry: " + questFile, e);
                     continue;
                 }
-                
+
                 // === CHAPTER INFO ===
-                
-                if(questFile.getName().equalsIgnoreCase("chapter.nbt"))
-                {
+
+                if (questFile.getName().equalsIgnoreCase("chapter.nbt")) {
                     questLine.setProperty(NativeProps.NAME, qTag.getString("title"));
                     NBTTagList desc = qTag.getTagList("description", 8);
                     StringBuilder sb = new StringBuilder();
-                    for(int i = 0; i < desc.tagCount(); i++)
-                    {
+                    for (int i = 0; i < desc.tagCount(); i++) {
                         sb.append(desc.getStringTagAt(i));
-                        if(i + 1 < desc.tagCount()) sb.append("\n");
+                        if (i + 1 < desc.tagCount()) sb.append("\n");
                     }
                     questLine.setProperty(NativeProps.DESC, sb.toString());
                     continue;
                 }
-                
+
                 // === QUEST DATA ===
-                
-                String hexID = questFile.getName().substring(0, questFile.getName().length() - 4);
+
+                String hexID =
+                        questFile.getName().substring(0, questFile.getName().length() - 4);
                 int questID = questDB.nextID();
                 IQuest quest = questDB.createNew(questID);
                 IQuestLineEntry qle = questLine.createNew(questID);
-                ID_MAP.put(hexID, new FTBEntry(questID, quest, FTBEntryType.QUEST)); // Add this to the weird ass ID mapping
+                ID_MAP.put(
+                        hexID,
+                        new FTBEntry(questID, quest, FTBEntryType.QUEST)); // Add this to the weird ass ID mapping
                 quest.setProperty(NativeProps.NAME, qTag.hasKey("title", 8) ? qTag.getString("title") : hexID);
                 NBTTagList desc = qTag.getTagList("text", 8);
                 StringBuilder sb = new StringBuilder();
-                for(int i = 0; i < desc.tagCount(); i++)
-                {
+                for (int i = 0; i < desc.tagCount(); i++) {
                     sb.append(desc.getStringTagAt(i));
-                    if(i + 1 < desc.tagCount()) sb.append("\n");
+                    if (i + 1 < desc.tagCount()) sb.append("\n");
                 }
                 quest.setProperty(NativeProps.DESC, sb.toString());
                 quest.setProperty(NativeProps.VISIBILITY, EnumQuestVisibility.ALWAYS);
-                
-                if(qTag.hasKey("icon"))
-                {
-                    // We're not even going to try and make an equivalent dynamic icon (although BQ could support it later)
+
+                if (qTag.hasKey("icon")) {
+                    // We're not even going to try and make an equivalent dynamic icon (although BQ could support it
+                    // later)
                     BigItemStack icoStack = FTBQUtils.convertItem(qTag.getTag("icon"));
-                    if(icoStack.getBaseStack() != null) quest.setProperty(NativeProps.ICON, icoStack);
+                    if (icoStack.getBaseStack() != null) quest.setProperty(NativeProps.ICON, icoStack);
                     requestIcon(null);
-                } else
-                {
+                } else {
                     requestIcon(quest);
                 }
-                qle.setPosition(qTag.getInteger("x") * 24, qTag.getInteger("y") * 24); // Fun Fact: FTBQ has a hard limit of -25 to +25 for it's quest coordinates even if you try forcing it higher
-                
+                qle.setPosition(
+                        qTag.getInteger("x") * 24,
+                        qTag.getInteger("y")
+                                * 24); // Fun Fact: FTBQ has a hard limit of -25 to +25 for it's quest coordinates even
+                // if you try forcing it higher
+
                 // === PARENTING INFO ===
-                
+
                 int[] depend = null; // Seriously?! WTF is with this format swapping names and datatypes?!
-                if(qTag.hasKey("dependencies", 11)) depend = qTag.getIntArray("dependencies");
-                if(qTag.hasKey("dependency", 3)) depend = new int[]{qTag.getInteger("dependency")};
-                
-                if(depend != null && depend.length > 0)
-                {
+                if (qTag.hasKey("dependencies", 11)) depend = qTag.getIntArray("dependencies");
+                if (qTag.hasKey("dependency", 3)) depend = new int[] {qTag.getInteger("dependency")};
+
+                if (depend != null && depend.length > 0) {
                     String[] depKeys = new String[depend.length];
-                    for(int d = 0; d < depend.length; d++) depKeys[d] = String.format("%1$08x", depend[d]);
+                    for (int d = 0; d < depend.length; d++) depKeys[d] = String.format("%1$08x", depend[d]);
                     parentMap.put(quest, depKeys);
                 }
-                
+
                 // === IMPORT TASKS ===
-                
+
                 NBTTagList taskList = qTag.getTagList("tasks", 10);
-                for(int i = 0; i < taskList.tagCount(); i++)
-                {
+                for (int i = 0; i < taskList.tagCount(); i++) {
                     NBTTagCompound taskTag = taskList.getCompoundTagAt(i);
                     String tType = taskTag.getString("type");
-                    if(!taskConverters.containsKey(tType))
-                    {
+                    if (!taskConverters.containsKey(tType)) {
                         BQ_Standard.logger.warn("Unsupported FTBQ task \"" + tType + "\"! Skipping...");
                         continue;
                     }
-                    
+
                     ITask[] tsks = taskConverters.get(tType).apply(taskTag);
-                    
-                    if(tsks != null && tsks.length > 0)
-                    {
+
+                    if (tsks != null && tsks.length > 0) {
                         IDatabaseNBT<ITask, NBTTagList, NBTTagList> taskReg = quest.getTasks();
-                        for(ITask t : tsks) taskReg.add(taskReg.nextID(), t);
+                        for (ITask t : tsks) taskReg.add(taskReg.nextID(), t);
                     }
                 }
-                
+
                 // === IMPORT REWARDS ===
-                
+
                 NBTTagList rewardList = qTag.getTagList("rewards", 10);
-                for(int i = 0; i < rewardList.tagCount(); i++)
-                {
+                for (int i = 0; i < rewardList.tagCount(); i++) {
                     NBTTagCompound rewTag = rewardList.getCompoundTagAt(i);
                     String rType = rewTag.getString("type");
-                    if(!rewardConverters.containsKey(rType))
-                    {
+                    if (!rewardConverters.containsKey(rType)) {
                         BQ_Standard.logger.warn("Unsupported FTBQ reward \"" + rType + "\"! Skipping...");
                         continue;
                     }
-                    
+
                     IReward[] tsks = rewardConverters.get(rType).apply(rewTag);
-                    
-                    if(tsks != null && tsks.length > 0)
-                    {
+
+                    if (tsks != null && tsks.length > 0) {
                         IDatabaseNBT<IReward, NBTTagList, NBTTagList> rewardReg = quest.getRewards();
-                        for(IReward t : tsks) rewardReg.add(rewardReg.nextID(), t);
+                        for (IReward t : tsks) rewardReg.add(rewardReg.nextID(), t);
                     }
                 }
             }
         }
-        
+
         // === PARENTING SET ===
-        
-        for(Entry<IQuest,String[]> entry : parentMap.entrySet())
-        {
+
+        for (Entry<IQuest, String[]> entry : parentMap.entrySet()) {
             List<Integer> qIDs = new ArrayList<>();
-            
-            for(String key : entry.getValue())
-            {
+
+            for (String key : entry.getValue()) {
                 FTBEntry type = ID_MAP.get(key);
-                
-                if(type == null)
-                {
+
+                if (type == null) {
                     BQ_Standard.logger.warn("Unable to find quest dependency '" + key + "'");
                     continue;
-                } else if(type.type == FTBEntryType.VAR) continue;
-                
-                if(type.type == FTBEntryType.QUEST)
-                {
-                    qIDs.add(questDB.getID((IQuest)type.obj));
-                } else if(type.type == FTBEntryType.LINE)
-                {
-                    for(DBEntry<IQuestLineEntry> qle : ((IQuestLine)type.obj).getEntries()) qIDs.add(qle.getID());
+                } else if (type.type == FTBEntryType.VAR) continue;
+
+                if (type.type == FTBEntryType.QUEST) {
+                    qIDs.add(questDB.getID((IQuest) type.obj));
+                } else if (type.type == FTBEntryType.LINE) {
+                    for (DBEntry<IQuestLineEntry> qle : ((IQuestLine) type.obj).getEntries()) qIDs.add(qle.getID());
                 }
             }
-            
+
             int[] preReq = new int[qIDs.size()];
-            for(int i = 0; i < qIDs.size(); i++) preReq[i] = qIDs.get(i);
+            for (int i = 0; i < qIDs.size(); i++) preReq[i] = qIDs.get(i);
             entry.getKey().setRequirements(preReq);
         }
     }
-    
+
     private static IQuest iconQuest;
-    
-    private static void requestIcon(IQuest quest)
-    {
+
+    private static void requestIcon(IQuest quest) {
         iconQuest = quest;
     }
-    
-    public static void provideIcon(BigItemStack stack)
-    {
-        if(iconQuest != null && stack != null)
-        {
+
+    public static void provideIcon(BigItemStack stack) {
+        if (iconQuest != null && stack != null) {
             iconQuest.setProperty(NativeProps.ICON, stack);
             iconQuest = null; // Request fufilled
         }
     }
-    
-    static
-    {
+
+    static {
         taskConverters.put("item", new FtbqTaskItem()::convertTask);
         taskConverters.put("fluid", new FtbqTaskFluid()::convertTask);
         taskConverters.put("forge_energy", new FtbqTaskEnergy()::converTask);
@@ -273,8 +247,8 @@ public class FTBQQuestImporter implements IImporter
         taskConverters.put("stat", new FtbqTaskStat()::convertTask);
         taskConverters.put("kill", new FtbqTaskKill()::convertTask);
         taskConverters.put("location", new FtbqTaskLocation()::convertTask);
-        taskConverters.put("checkmark", tag -> new ITask[]{new TaskCheckbox()});
-        
+        taskConverters.put("checkmark", tag -> new ITask[] {new TaskCheckbox()});
+
         rewardConverters.put("item", new FtbqRewardItem()::convertTask);
         rewardConverters.put("xp", new FtbqRewardXP(false)::convertTask);
         rewardConverters.put("xp_levels", new FtbqRewardXP(true)::convertTask);

--- a/src/main/java/bq_standard/importers/ftbq/FTBQUtils.java
+++ b/src/main/java/bq_standard/importers/ftbq/FTBQUtils.java
@@ -7,53 +7,44 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagString;
 
-public class FTBQUtils
-{
-    public static BigItemStack convertItem(NBTBase tag)
-    {
-        if(tag instanceof NBTTagString)
-        {
-            return convertItemType1(((NBTTagString)tag).func_150285_a_());
-        } else if(tag instanceof NBTTagCompound)
-        {
-            return convertItemType2((NBTTagCompound)tag);
+public class FTBQUtils {
+    public static BigItemStack convertItem(NBTBase tag) {
+        if (tag instanceof NBTTagString) {
+            return convertItemType1(((NBTTagString) tag).func_150285_a_());
+        } else if (tag instanceof NBTTagCompound) {
+            return convertItemType2((NBTTagCompound) tag);
         }
-        
+
         return null;
     }
-    
-    private static BigItemStack convertItemType1(String string)
-    {
+
+    private static BigItemStack convertItemType1(String string) {
         String[] split = string.split(" ");
-        if(split.length <= 0) return null;
-        
-        Item item = (Item)Item.itemRegistry.getObject(split[0]);
+        if (split.length <= 0) return null;
+
+        Item item = (Item) Item.itemRegistry.getObject(split[0]);
         int count = split.length < 2 ? 1 : tryParseInt(split[1], 1);
         int meta = split.length < 3 ? 0 : tryParseInt(split[2], 0);
-        
+
         return PlaceholderConverter.convertItem(item, split[0], count, meta, "", null);
     }
-    
-    private static BigItemStack convertItemType2(NBTTagCompound tag)
-    {
+
+    private static BigItemStack convertItemType2(NBTTagCompound tag) {
         String[] split = tag.getString("id").split(" ");
-        if(split.length <= 0) return null;
-        
-        Item item = (Item)Item.itemRegistry.getObject(split[0]);
+        if (split.length <= 0) return null;
+
+        Item item = (Item) Item.itemRegistry.getObject(split[0]);
         int count = split.length < 2 ? 1 : tryParseInt(split[1], 1);
         int meta = split.length < 3 ? 0 : tryParseInt(split[2], 0);
         NBTTagCompound tags = !tag.hasKey("tag", 10) ? null : tag.getCompoundTag("tag");
-        
+
         return PlaceholderConverter.convertItem(item, split[0], count, meta, "", tags);
     }
-    
-    private static int tryParseInt(String text, int def)
-    {
-        try
-        {
+
+    private static int tryParseInt(String text, int def) {
+        try {
             return Integer.parseInt(text);
-        } catch(NumberFormatException e)
-        {
+        } catch (NumberFormatException e) {
             return def;
         }
     }

--- a/src/main/java/bq_standard/importers/ftbq/converters/rewards/FtbqRewardCommand.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/rewards/FtbqRewardCommand.java
@@ -4,14 +4,13 @@ import betterquesting.api.questing.rewards.IReward;
 import bq_standard.rewards.RewardCommand;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class FtbqRewardCommand
-{
-    public IReward[] convertReward(NBTTagCompound tag)
-    {
+public class FtbqRewardCommand {
+    public IReward[] convertReward(NBTTagCompound tag) {
         RewardCommand reward = new RewardCommand();
         reward.viaPlayer = false; // FTBQ only runs as server
-        reward.hideCmd = tag.getString("title").length() > 0; // We can't support showing the title (yet) but we can at least hide it
+        reward.hideCmd = tag.getString("title").length()
+                > 0; // We can't support showing the title (yet) but we can at least hide it
         reward.command = tag.getString("command");
-        return new IReward[]{reward};
+        return new IReward[] {reward};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/rewards/FtbqRewardItem.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/rewards/FtbqRewardItem.java
@@ -5,14 +5,12 @@ import bq_standard.importers.ftbq.FTBQUtils;
 import bq_standard.rewards.RewardItem;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class FtbqRewardItem
-{
-    public IReward[] convertTask(NBTTagCompound tag)
-    {
+public class FtbqRewardItem {
+    public IReward[] convertTask(NBTTagCompound tag) {
         RewardItem reward = new RewardItem();
-        
+
         reward.items.add(FTBQUtils.convertItem(tag.getTag("item"))); // One item per reward. Isn't that a PITA?
-        
-        return new IReward[]{reward};
+
+        return new IReward[] {reward};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/rewards/FtbqRewardXP.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/rewards/FtbqRewardXP.java
@@ -4,20 +4,17 @@ import betterquesting.api.questing.rewards.IReward;
 import bq_standard.rewards.RewardXP;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class FtbqRewardXP
-{
+public class FtbqRewardXP {
     private final boolean isLevels;
-    
-    public FtbqRewardXP(boolean isLevels)
-    {
+
+    public FtbqRewardXP(boolean isLevels) {
         this.isLevels = isLevels;
     }
-    
-    public IReward[] convertTask(NBTTagCompound tag)
-    {
+
+    public IReward[] convertTask(NBTTagCompound tag) {
         RewardXP reward = new RewardXP();
         reward.levels = this.isLevels;
         reward.amount = isLevels ? tag.getInteger("xp_levels") : tag.getInteger("xp");
-        return new IReward[]{reward};
+        return new IReward[] {reward};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskDimension.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskDimension.java
@@ -7,12 +7,10 @@ import bq_standard.tasks.TaskLocation;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class FtbqTaskDimension
-{
-    public ITask[] converTask(NBTTagCompound tag)
-    {
+public class FtbqTaskDimension {
+    public ITask[] converTask(NBTTagCompound tag) {
         TaskLocation task = new TaskLocation();
-        
+
         task.range = -1;
         task.dim = tag.getInteger("dim");
         task.x = 0;
@@ -20,9 +18,9 @@ public class FtbqTaskDimension
         task.z = 0;
         task.visible = true;
         task.name = tag.hasKey("title", 8) ? tag.getString("title") : TaskLocation.getDimName(task.dim);
-    
+
         FTBQQuestImporter.provideIcon(new BigItemStack(Blocks.portal));
-        
-        return new ITask[]{task};
+
+        return new ITask[] {task};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskEnergy.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskEnergy.java
@@ -10,28 +10,25 @@ import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FtbqTaskEnergy
-{
-    // With a little magic we're going to support this without having to reference RF Expansion nor even have it installed!
-    public ITask[] converTask(NBTTagCompound tag)
-    {
+public class FtbqTaskEnergy {
+    // With a little magic we're going to support this without having to reference RF Expansion nor even have it
+    // installed!
+    public ITask[] converTask(NBTTagCompound tag) {
         NBTTagCompound rfTaskTag = new NBTTagCompound();
         rfTaskTag.setString("taskID", "bq_rf:rf_charge");
         rfTaskTag.setLong("rf", tag.getLong("value"));
-        
+
         ITask task = QuestingAPI.getAPI(ApiReference.TASK_REG).createNew(new ResourceLocation("bq_rf:rf_charge"));
-        
-        if(task == null)
-        {
+
+        if (task == null) {
             task = new TaskPlaceholder();
-            ((TaskPlaceholder)task).setTaskConfigData(rfTaskTag);
-        } else
-        {
+            ((TaskPlaceholder) task).setTaskConfigData(rfTaskTag);
+        } else {
             task.readFromNBT(rfTaskTag);
         }
-    
+
         FTBQQuestImporter.provideIcon(new BigItemStack(Blocks.redstone_block));
-        
-        return new ITask[]{task};
+
+        return new ITask[] {task};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskFluid.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskFluid.java
@@ -11,29 +11,28 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-public class FtbqTaskFluid
-{
-    public ITask[] convertTask(NBTTagCompound nbt)
-    {
+public class FtbqTaskFluid {
+    public ITask[] convertTask(NBTTagCompound nbt) {
         String fName = nbt.getString("fluid");
         Fluid fluid = FluidRegistry.getFluid(fName);
         long amount = nbt.getLong("amount"); // Sigh... longs again. No matter, we'll just split them if they're too big
-        NBTTagCompound tag = !nbt.hasKey("tag", 10) ? null : nbt.getCompoundTag("tag"); // FTBQ doesn't support tags yet but we'll try supporting it in advance
+        NBTTagCompound tag = !nbt.hasKey("tag", 10)
+                ? null
+                : nbt.getCompoundTag("tag"); // FTBQ doesn't support tags yet but we'll try supporting it in advance
         FluidStack stack = PlaceholderConverter.convertFluid(fluid, fName, 1, tag);
-        
+
         TaskFluid task = new TaskFluid();
-        
+
         long rem = amount;
-        while(rem > 0)
-        {
-            int split = (int)(rem % Integer.MAX_VALUE);
+        while (rem > 0) {
+            int split = (int) (rem % Integer.MAX_VALUE);
             stack.amount = split;
             task.requiredFluids.add(stack.copy());
             rem -= split;
         }
-    
+
         FTBQQuestImporter.provideIcon(new BigItemStack(Items.bucket));
-        
-        return new ITask[]{task};
+
+        return new ITask[] {task};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskItem.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskItem.java
@@ -9,62 +9,63 @@ import bq_standard.tasks.TaskRetrieval;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
-public class FtbqTaskItem
-{
+public class FtbqTaskItem {
     /*
     NOTE:
     Due to the wierd way these tasks work with item lists means that during conversion its behaviour will transition from OR logic to AND logic.
     No I'm not going to fix this. Pack devs can spend their own time changing it out if they really need to
     */
-    public ITask[] convertTask(NBTTagCompound nbt)
-    {
+    public ITask[] convertTask(NBTTagCompound nbt) {
         TaskRetrieval task = new TaskRetrieval();
-        task.consume = nbt.getBoolean("consume_items"); // If the default were changed to true and this was redacted then too bad. I'm not going looking for the root file just for this task
-        long count = !nbt.hasKey("count") ? 1 : nbt.getLong("count"); // Why this isn't per item I have no idea. Ask the FTBQ dev. Also not a fan of supporting stack counts in excess of 2 BILLION items.
-        
-        if(nbt.hasKey("item", 8) || nbt.hasKey("item", 10))
-        {
+        task.consume = nbt.getBoolean(
+                "consume_items"); // If the default were changed to true and this was redacted then too bad. I'm not
+        // going looking for the root file just for this task
+        long count = !nbt.hasKey("count")
+                ? 1
+                : nbt.getLong("count"); // Why this isn't per item I have no idea. Ask the FTBQ dev. Also not a fan of
+        // supporting stack counts in excess of 2 BILLION items.
+
+        if (nbt.hasKey("item", 8) || nbt.hasKey("item", 10)) {
             BigItemStack item = FTBQUtils.convertItem(nbt.getTag("item"));
             long rem = count;
-            
-            while(rem > 0)
-            {
-                int split = (int)(rem % Integer.MAX_VALUE);
+
+            while (rem > 0) {
+                int split = (int) (rem % Integer.MAX_VALUE);
                 item.stackSize = split;
                 task.requiredItems.add(item.copy());
                 rem -= split;
             }
-            
+
             FTBQQuestImporter.provideIcon(item);
-        } else if(nbt.hasKey("items", 9)) // Note: Non-NBT items in this list are stored in Compound > String because... I have no idea
+        } else if (nbt.hasKey(
+                "items",
+                9)) // Note: Non-NBT items in this list are stored in Compound > String because... I have no idea
         {
             NBTTagList tagList = nbt.getTagList("items", 10);
-            for(int i = 0; i < tagList.tagCount(); i++)
-            {
+            for (int i = 0; i < tagList.tagCount(); i++) {
                 NBTTagCompound tagItemBase = tagList.getCompoundTagAt(i);
                 BigItemStack item;
                 long rem = count;
-                
-                if(tagItemBase.hasKey("item", 8)) // Need to check the sub tag is a string
+
+                if (tagItemBase.hasKey("item", 8)) // Need to check the sub tag is a string
                 {
                     item = FTBQUtils.convertItem(tagItemBase.getTag("item"));
                 } else // Tag itself is the item... probably
                 {
                     item = FTBQUtils.convertItem(tagItemBase);
                 }
-                
-                while(rem > 0)
-                {
-                    int split = (int)(rem % Integer.MAX_VALUE);
+
+                while (rem > 0) {
+                    int split = (int) (rem % Integer.MAX_VALUE);
                     item.stackSize = split;
                     task.requiredItems.add(item.copy());
                     rem -= split;
                 }
-                
+
                 FTBQQuestImporter.provideIcon(item);
             }
         } else BQ_Standard.logger.error("Unable read item tag!");
-        
-        return new ITask[]{task};
+
+        return new ITask[] {task};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskKill.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskKill.java
@@ -7,20 +7,18 @@ import bq_standard.tasks.TaskHunt;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class FtbqTaskKill
-{
-    public ITask[] convertTask(NBTTagCompound tag)
-    {
+public class FtbqTaskKill {
+    public ITask[] convertTask(NBTTagCompound tag) {
         TaskHunt task = new TaskHunt();
-        
+
         task.idName = tag.getString("entity");
         task.targetTags = new NBTTagCompound();
         task.required = tag.getInteger("value");
         task.ignoreNBT = true;
         task.subtypes = true;
-    
+
         FTBQQuestImporter.provideIcon(new BigItemStack(Items.diamond_sword));
-        
-        return new ITask[]{task};
+
+        return new ITask[] {task};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskLocation.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskLocation.java
@@ -7,25 +7,23 @@ import bq_standard.tasks.TaskLocation;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class FtbqTaskLocation
-{
-    public ITask[] convertTask(NBTTagCompound tag)
-    {
+public class FtbqTaskLocation {
+    public ITask[] convertTask(NBTTagCompound tag) {
         TaskLocation task = new TaskLocation();
-        
+
         int[] data = tag.getIntArray("location");
-        if(data.length <= 7) return null; // Just incase soemthing was redacted for some reason
-        
+        if (data.length <= 7) return null; // Just incase soemthing was redacted for some reason
+
         task.dim = data[0];
         task.x = data[1];
         task.y = data[2];
         task.z = data[3];
         task.range = Math.min(data[4], Math.min(data[5], data[6])); // FTBQ uses a dimension task for infinite range
-        if(task.range <= 0) task.range = 1; // Sanity checking
-        
+        if (task.range <= 0) task.range = 1; // Sanity checking
+
         task.name = tag.hasKey("title", 8) ? tag.getString("title") : TaskLocation.getDimName(task.dim);
         FTBQQuestImporter.provideIcon(new BigItemStack(Items.compass));
-        
-        return new ITask[]{task};
+
+        return new ITask[] {task};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskStat.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskStat.java
@@ -8,19 +8,17 @@ import bq_standard.tasks.TaskScoreboard.ScoreOperation;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class FtbqTaskStat
-{
-    public ITask[] convertTask(NBTTagCompound tag)
-    {
+public class FtbqTaskStat {
+    public ITask[] convertTask(NBTTagCompound tag) {
         TaskScoreboard task = new TaskScoreboard();
-        
+
         task.scoreName = tag.getString("stat");
         task.scoreDisp = tag.hasKey("title", 8) ? tag.getString("title") : task.scoreName;
         task.operation = ScoreOperation.MORE_OR_EQUAL;
         task.target = tag.getInteger("value");
-    
+
         FTBQQuestImporter.provideIcon(new BigItemStack(Items.paper));
-        
-        return new ITask[]{task};
+
+        return new ITask[] {task};
     }
 }

--- a/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskXP.java
+++ b/src/main/java/bq_standard/importers/ftbq/converters/tasks/FtbqTaskXP.java
@@ -7,19 +7,18 @@ import bq_standard.tasks.TaskXP;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class FtbqTaskXP
-{
+public class FtbqTaskXP {
     /*
-        Fun Fact:
-        As of writing this, FTBQ doesn't care if the level you submit to its task is from level 30 or level 1. This means high level players get screwed over. GG
-     */
-    public ITask[] convertTask(NBTTagCompound tag)
-    {
+       Fun Fact:
+       As of writing this, FTBQ doesn't care if the level you submit to its task is from level 30 or level 1. This means high level players get screwed over. GG
+    */
+    public ITask[] convertTask(NBTTagCompound tag) {
         TaskXP task = new TaskXP();
         task.consume = true; // FTBQ is consume only. Not really sure why it doesn't allow detect
-        task.amount = (int)(tag.getLong("value") % Integer.MAX_VALUE); // Suuuure FTBQ. The vanilla int XP level can totally exceed 2.14B
+        task.amount = (int) (tag.getLong("value")
+                % Integer.MAX_VALUE); // Suuuure FTBQ. The vanilla int XP level can totally exceed 2.14B
         FTBQQuestImporter.provideIcon(new BigItemStack(Items.experience_bottle));
-        
-        return new ITask[]{task};
+
+        return new ITask[] {task};
     }
 }

--- a/src/main/java/bq_standard/importers/hqm/HQMBagImporter.java
+++ b/src/main/java/bq_standard/importers/hqm/HQMBagImporter.java
@@ -12,9 +12,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
@@ -22,146 +19,126 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 
-public class HQMBagImporter implements IImporter
-{
-	public static final HQMBagImporter INSTANCE = new HQMBagImporter();
-	
-	private List<LootGroup> hqmLoot = new ArrayList<>();
-	
-	@Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.importer.hqm_bag.name";
-	}
-	
-	@Override
-	public String getUnlocalisedDescription()
-	{
-		return "bq_standard.importer.hqm_bag.desc";
-	}
-	
-	@Override
-	public FileFilter getFileFilter()
-	{
-		return new FileExtensionFilter(".json");
-	}
-	
-	private void ImportJsonBags(JsonArray json)
-	{
-		for(JsonElement e : json)
-		{
-			if(e == null || !e.isJsonObject())
-			{
-				continue;
-			}
-			
-			JsonObject jGrp = e.getAsJsonObject();
-			
-			LootGroup group = new LootGroup();
-			group.name = JsonHelper.GetString(jGrp, "name", "HQM Loot");
-			try
-			{
-				int tmp = 0;
-				
-				JsonArray jWht = JsonHelper.GetArray(jGrp, "weights");
-				
-				for(int i = 0; i < jWht.size(); i++)
-				{
-					JsonElement w = jWht.get(i);
-					
-					if(w == null || !w.isJsonPrimitive() || !w.getAsJsonPrimitive().isNumber())
-					{
-						continue;
-					}
-					
-					tmp += w.getAsInt() * (jWht.size() - i);
-				}
-				
-				group.weight = Math.max(1, tmp/4);
-			} catch(Exception ex)
-			{
-				group.weight = 1;
-			}
-			
-			for(JsonElement e2 : JsonHelper.GetArray(jGrp, "groups"))
-			{
-				if(e2 == null || !e2.isJsonObject())
-				{
-					continue;
-				}
-				
-				JsonObject je = e2.getAsJsonObject();
-				LootEntry lEntry = new LootEntry();
-				lEntry.weight = JsonHelper.GetNumber(je, "limit", 1).intValue();
-				for(JsonElement ji : JsonHelper.GetArray(je, "items"))
-				{
-					if(ji == null || !ji.isJsonObject())
-					{
-						continue;
-					}
-					
-					lEntry.items.add(HQMUtilities.HQMStackT1(ji.getAsJsonObject()));
-				}
-				group.add(group.nextID(), lEntry);
-			}
-			
-			hqmLoot.add(group);
-		}
-	}
+public class HQMBagImporter implements IImporter {
+    public static final HQMBagImporter INSTANCE = new HQMBagImporter();
 
-	@Override
-	public void loadFiles(IQuestDatabase questDB, IQuestLineDatabase lineDB, File[] files)
-	{
-		hqmLoot.clear();
-		
-		for(File selected : files)
-		{
-			if(selected == null || !selected.exists())
-			{
-				continue;
-			}
-			
-			JsonArray json = ReadFromFile(selected);
-			
-			if(json != null && json.size() > 0)
-			{
-				ImportJsonBags(json);
-			}
-		}
-		
-		NBTTagCompound tags = new NBTTagCompound();
-		NBTTagCompound base = new NBTTagCompound();
-		NBTTagList jAry = new NBTTagList();
-		
-		for(LootGroup group : hqmLoot)
-		{
-			NBTTagCompound jGrp = new NBTTagCompound();
-			group.writeToNBT(jGrp);
-			jAry.appendTag(jGrp);
-		}
-		
-		base.setTag("groups", jAry);
-		tags.setTag("data", base);
+    private List<LootGroup> hqmLoot = new ArrayList<>();
+
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.importer.hqm_bag.name";
+    }
+
+    @Override
+    public String getUnlocalisedDescription() {
+        return "bq_standard.importer.hqm_bag.desc";
+    }
+
+    @Override
+    public FileFilter getFileFilter() {
+        return new FileExtensionFilter(".json");
+    }
+
+    private void ImportJsonBags(JsonArray json) {
+        for (JsonElement e : json) {
+            if (e == null || !e.isJsonObject()) {
+                continue;
+            }
+
+            JsonObject jGrp = e.getAsJsonObject();
+
+            LootGroup group = new LootGroup();
+            group.name = JsonHelper.GetString(jGrp, "name", "HQM Loot");
+            try {
+                int tmp = 0;
+
+                JsonArray jWht = JsonHelper.GetArray(jGrp, "weights");
+
+                for (int i = 0; i < jWht.size(); i++) {
+                    JsonElement w = jWht.get(i);
+
+                    if (w == null
+                            || !w.isJsonPrimitive()
+                            || !w.getAsJsonPrimitive().isNumber()) {
+                        continue;
+                    }
+
+                    tmp += w.getAsInt() * (jWht.size() - i);
+                }
+
+                group.weight = Math.max(1, tmp / 4);
+            } catch (Exception ex) {
+                group.weight = 1;
+            }
+
+            for (JsonElement e2 : JsonHelper.GetArray(jGrp, "groups")) {
+                if (e2 == null || !e2.isJsonObject()) {
+                    continue;
+                }
+
+                JsonObject je = e2.getAsJsonObject();
+                LootEntry lEntry = new LootEntry();
+                lEntry.weight = JsonHelper.GetNumber(je, "limit", 1).intValue();
+                for (JsonElement ji : JsonHelper.GetArray(je, "items")) {
+                    if (ji == null || !ji.isJsonObject()) {
+                        continue;
+                    }
+
+                    lEntry.items.add(HQMUtilities.HQMStackT1(ji.getAsJsonObject()));
+                }
+                group.add(group.nextID(), lEntry);
+            }
+
+            hqmLoot.add(group);
+        }
+    }
+
+    @Override
+    public void loadFiles(IQuestDatabase questDB, IQuestLineDatabase lineDB, File[] files) {
+        hqmLoot.clear();
+
+        for (File selected : files) {
+            if (selected == null || !selected.exists()) {
+                continue;
+            }
+
+            JsonArray json = ReadFromFile(selected);
+
+            if (json != null && json.size() > 0) {
+                ImportJsonBags(json);
+            }
+        }
+
+        NBTTagCompound tags = new NBTTagCompound();
+        NBTTagCompound base = new NBTTagCompound();
+        NBTTagList jAry = new NBTTagList();
+
+        for (LootGroup group : hqmLoot) {
+            NBTTagCompound jGrp = new NBTTagCompound();
+            group.writeToNBT(jGrp);
+            jAry.appendTag(jGrp);
+        }
+
+        base.setTag("groups", jAry);
+        tags.setTag("data", base);
         NetLootImport.importLoot(tags);
-	}
-	
-	private JsonArray ReadFromFile(File file)
-	{
-		if(file == null || !file.exists())
-		{
-			return new JsonArray();
-		}
-		
-		try
-		{
-			InputStreamReader fr = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
-			JsonArray json = new Gson().fromJson(fr, JsonArray.class);
-			fr.close();
-			return json;
-		} catch(Exception e)
-		{
-			return new JsonArray(); // Just a safety measure against NPEs
-		}
-	}
+    }
+
+    private JsonArray ReadFromFile(File file) {
+        if (file == null || !file.exists()) {
+            return new JsonArray();
+        }
+
+        try {
+            InputStreamReader fr = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
+            JsonArray json = new Gson().fromJson(fr, JsonArray.class);
+            fr.close();
+            return json;
+        } catch (Exception e) {
+            return new JsonArray(); // Just a safety measure against NPEs
+        }
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/HQMQuestImporter.java
+++ b/src/main/java/bq_standard/importers/hqm/HQMQuestImporter.java
@@ -16,10 +16,6 @@ import bq_standard.importers.hqm.converters.HQMRep;
 import bq_standard.importers.hqm.converters.rewards.*;
 import bq_standard.importers.hqm.converters.tasks.*;
 import com.google.gson.*;
-import net.minecraft.init.Items;
-import net.minecraft.nbt.NBTTagList;
-import org.apache.logging.log4j.Level;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
@@ -32,364 +28,331 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.Future;
 import java.util.function.Function;
+import net.minecraft.init.Items;
+import net.minecraft.nbt.NBTTagList;
+import org.apache.logging.log4j.Level;
 
-public class HQMQuestImporter implements IImporter
-{
-	public static final HQMQuestImporter INSTANCE = new HQMQuestImporter();
-	private static final FileFilter FILTER = new FileExtensionFilter(".json");
-	
-	private static HashMap<String, Function<JsonObject, ITask[]>> taskConverters = new HashMap<>();
-	private static HashMap<String, Function<JsonElement, IReward[]>> rewardConverters = new HashMap<>();
-	
-	public HashMap<String, HQMRep> reputations = new HashMap<>();
-	
-	private HashMap<String, IQuest> idMap = new HashMap<>(); // Use this to remap old IDs to new ones
-	
-	@Override
-	public FileFilter getFileFilter()
-	{
-		return FILTER;
-	}
+public class HQMQuestImporter implements IImporter {
+    public static final HQMQuestImporter INSTANCE = new HQMQuestImporter();
+    private static final FileFilter FILTER = new FileExtensionFilter(".json");
 
-	@Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.importer.hqm_quest.name";
-	}
+    private static HashMap<String, Function<JsonObject, ITask[]>> taskConverters = new HashMap<>();
+    private static HashMap<String, Function<JsonElement, IReward[]>> rewardConverters = new HashMap<>();
 
-	@Override
-	public String getUnlocalisedDescription()
-	{
-		return "bq_standard.importer.hqm_quest.desc";
-	}
+    public HashMap<String, HQMRep> reputations = new HashMap<>();
 
-	@Override
-	public void loadFiles(IQuestDatabase questDB, IQuestLineDatabase lineDB, File[] files)
-	{
-		reputations.clear();
-		idMap.clear();
-		
-		for(File selected : files) // Pre-search for reputations required for tasks
-		{
-			if(selected == null || !selected.exists() || !selected.getName().equalsIgnoreCase("reputations.json")) continue;
-			
-			JsonArray json = ReadArrayFromFile(selected);
-			LoadReputations(json);
+    private HashMap<String, IQuest> idMap = new HashMap<>(); // Use this to remap old IDs to new ones
+
+    @Override
+    public FileFilter getFileFilter() {
+        return FILTER;
+    }
+
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.importer.hqm_quest.name";
+    }
+
+    @Override
+    public String getUnlocalisedDescription() {
+        return "bq_standard.importer.hqm_quest.desc";
+    }
+
+    @Override
+    public void loadFiles(IQuestDatabase questDB, IQuestLineDatabase lineDB, File[] files) {
+        reputations.clear();
+        idMap.clear();
+
+        for (File selected : files) // Pre-search for reputations required for tasks
+        {
+            if (selected == null || !selected.exists() || !selected.getName().equalsIgnoreCase("reputations.json"))
+                continue;
+
+            JsonArray json = ReadArrayFromFile(selected);
+            LoadReputations(json);
         }
-		
-		for(File selected : files)
-		{
-			if(selected == null || !selected.exists() || selected.getName().equalsIgnoreCase("reputations.json")) continue;
-			
-			JsonObject json = JsonHelper.ReadFromFile(selected);
-			ImportQuestLine(questDB, lineDB, json);
-		}
-	}
-	
-	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-	
-	private static JsonArray ReadArrayFromFile(File file)
-	{
-		Future<JsonArray> task = BQThreadedIO.INSTANCE.enqueue(() -> {
-			if(file == null || !file.exists())
-			{
-				return new JsonArray();
-			}
-			
-			try(InputStreamReader fr = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))
-			{
-				return GSON.fromJson(fr, JsonArray.class);
-			} catch(Exception e)
-			{
-				QuestingAPI.getLogger().log(Level.ERROR, "An error occured while loading JSON from file:", e);
-				
-				int i = 0;
-				File bkup = new File(file.getParent(), "malformed_" + file.getName() + i + ".json");
-				
-				while(bkup.exists())
-				{
-					i++;
-					bkup = new File(file.getParent(), "malformed_" + file.getName() + i + ".json");
-				}
-				
-				QuestingAPI.getLogger().log(Level.ERROR, "Creating backup at: " + bkup.getAbsolutePath());
-				JsonHelper.CopyPaste(file, bkup);
-				
-				return new JsonArray(); // Just a safety measure against NPEs
-			}
-		});
-		
-		try
-		{
-			return task.get(); // Wait for other scheduled file ops to finish
-		} catch(Exception e)
-		{
-		    QuestingAPI.getLogger().error("Unable to read from file " + file, e);
-			return new JsonArray();
-		}
-	}
-	
-	private void LoadReputations(JsonArray jsonRoot)
-	{
-	    if(jsonRoot == null || jsonRoot.size() <= 0) return;
-	    
-		int i = -1;
-		
-		for(JsonElement e : jsonRoot)
-		{
-		    if(!(e instanceof JsonObject)) continue;
-		    JsonObject jRep = e.getAsJsonObject();
-		    
-		    String repName = "Reputation(" + i + ")";
-		    if(jRep.has("Name")) repName = JsonHelper.GetString(jRep, "Name", repName);
-		    if(jRep.has("name")) repName = JsonHelper.GetString(jRep, "name", repName);
-		    
-		    String repId = "" + (++i);
-		    if(jRep.has("Id")) repId = JsonHelper.GetNumber(jRep, "Id", i).toString();
-		    if(jRep.has("id")) repId = JsonHelper.GetString(jRep, "id", repId);
-		    
-		    
-		    HQMRep repObj = new HQMRep(repName);
-		    
-		    JsonArray mrkAry = null;
-		    if(jRep.has("Markers")) mrkAry = JsonHelper.GetArray(jRep, "Markers");
-		    if(mrkAry == null) mrkAry = JsonHelper.GetArray(jRep, "markers");
-		    
-		    for(int m = 0; m < mrkAry.size(); m++)
-            {
+
+        for (File selected : files) {
+            if (selected == null || !selected.exists() || selected.getName().equalsIgnoreCase("reputations.json"))
+                continue;
+
+            JsonObject json = JsonHelper.ReadFromFile(selected);
+            ImportQuestLine(questDB, lineDB, json);
+        }
+    }
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private static JsonArray ReadArrayFromFile(File file) {
+        Future<JsonArray> task = BQThreadedIO.INSTANCE.enqueue(() -> {
+            if (file == null || !file.exists()) {
+                return new JsonArray();
+            }
+
+            try (InputStreamReader fr = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
+                return GSON.fromJson(fr, JsonArray.class);
+            } catch (Exception e) {
+                QuestingAPI.getLogger().log(Level.ERROR, "An error occured while loading JSON from file:", e);
+
+                int i = 0;
+                File bkup = new File(file.getParent(), "malformed_" + file.getName() + i + ".json");
+
+                while (bkup.exists()) {
+                    i++;
+                    bkup = new File(file.getParent(), "malformed_" + file.getName() + i + ".json");
+                }
+
+                QuestingAPI.getLogger().log(Level.ERROR, "Creating backup at: " + bkup.getAbsolutePath());
+                JsonHelper.CopyPaste(file, bkup);
+
+                return new JsonArray(); // Just a safety measure against NPEs
+            }
+        });
+
+        try {
+            return task.get(); // Wait for other scheduled file ops to finish
+        } catch (Exception e) {
+            QuestingAPI.getLogger().error("Unable to read from file " + file, e);
+            return new JsonArray();
+        }
+    }
+
+    private void LoadReputations(JsonArray jsonRoot) {
+        if (jsonRoot == null || jsonRoot.size() <= 0) return;
+
+        int i = -1;
+
+        for (JsonElement e : jsonRoot) {
+            if (!(e instanceof JsonObject)) continue;
+            JsonObject jRep = e.getAsJsonObject();
+
+            String repName = "Reputation(" + i + ")";
+            if (jRep.has("Name")) repName = JsonHelper.GetString(jRep, "Name", repName);
+            if (jRep.has("name")) repName = JsonHelper.GetString(jRep, "name", repName);
+
+            String repId = "" + (++i);
+            if (jRep.has("Id")) repId = JsonHelper.GetNumber(jRep, "Id", i).toString();
+            if (jRep.has("id")) repId = JsonHelper.GetString(jRep, "id", repId);
+
+            HQMRep repObj = new HQMRep(repName);
+
+            JsonArray mrkAry = null;
+            if (jRep.has("Markers")) mrkAry = JsonHelper.GetArray(jRep, "Markers");
+            if (mrkAry == null) mrkAry = JsonHelper.GetArray(jRep, "markers");
+
+            for (int m = 0; m < mrkAry.size(); m++) {
                 JsonElement e2 = mrkAry.get(m);
-                if(!(e2 instanceof JsonObject)) continue;
-                
+                if (!(e2 instanceof JsonObject)) continue;
+
                 JsonObject jMark = e2.getAsJsonObject();
-                
+
                 int mId = m;
-                if(jMark.has("Id")) mId = JsonHelper.GetNumber(jMark, "Id", mId).intValue();
-                
+                if (jMark.has("Id"))
+                    mId = JsonHelper.GetNumber(jMark, "Id", mId).intValue();
+
                 int mVal = 0;
-                if(jMark.has("Value")) mVal = JsonHelper.GetNumber(jMark, "Value", mVal).intValue();
-                if(jMark.has("value")) mVal = JsonHelper.GetNumber(jMark, "value", mVal).intValue();
-                
+                if (jMark.has("Value"))
+                    mVal = JsonHelper.GetNumber(jMark, "Value", mVal).intValue();
+                if (jMark.has("value"))
+                    mVal = JsonHelper.GetNumber(jMark, "value", mVal).intValue();
+
                 repObj.addMarker(mId, mVal);
             }
-		    
-			reputations.put(repId, repObj);
-		}
-	}
-	
-	private IQuest GetNewQuest(String oldID, IQuestDatabase qdb)
-	{
-		if(idMap.containsKey(oldID))
-		{
-			return idMap.get(oldID);
-		} else
-		{
-			IQuest quest = qdb.createNew(qdb.nextID());
-			idMap.put(oldID, quest);
-			return quest;
-		}
-	}
-	
-	private void ImportQuestLine(IQuestDatabase questDB, IQuestLineDatabase lineDB, JsonObject json)
-	{
-		IQuestLine questLine = lineDB.createNew(lineDB.nextID());
+
+            reputations.put(repId, repObj);
+        }
+    }
+
+    private IQuest GetNewQuest(String oldID, IQuestDatabase qdb) {
+        if (idMap.containsKey(oldID)) {
+            return idMap.get(oldID);
+        } else {
+            IQuest quest = qdb.createNew(qdb.nextID());
+            idMap.put(oldID, quest);
+            return quest;
+        }
+    }
+
+    private void ImportQuestLine(IQuestDatabase questDB, IQuestLineDatabase lineDB, JsonObject json) {
+        IQuestLine questLine = lineDB.createNew(lineDB.nextID());
         questLine.setProperty(NativeProps.NAME, JsonHelper.GetString(json, "name", "HQM Quest Line"));
-		questLine.setProperty(NativeProps.DESC, JsonHelper.GetString(json, "description", "No description"));
-		
-		LoadReputations(JsonHelper.GetArray(json, "reputations"));
-		
-		JsonArray qlJson = JsonHelper.GetArray(json, "quests");
-		
-		List<String> loadedQuests = new ArrayList<>(); // Just in case we have duplicate named quests
-		
-		for(int i = 0; i < qlJson.size(); i++)
-		{
-			JsonElement element = qlJson.get(i);
-			
-			if(element == null || !element.isJsonObject())
-			{
-				continue;
-			}
-			
-			JsonObject jQuest = element.getAsJsonObject();
-			
-			String name = JsonHelper.GetString(jQuest, "name", "HQM Quest");
-			String idName = jQuest.has("uuid")? JsonHelper.GetString(jQuest, "uuid", name) : name;
-			
-			if(loadedQuests.contains(idName))
-			{
-				int n = 1;
-				while(loadedQuests.contains(idName + " (" + n + ")"))
-				{
-					n++;
-				}
-				BQ_Standard.logger.log(Level.WARN, "Found duplicate quest " + name + ". Any quests with this pre-requisite will need repair!");
-				idName = name + " (" + n + ")";
-			}
-			
-			loadedQuests.add(idName);
-			IQuest quest = GetNewQuest(idName, questDB);
-			
-			quest.setProperty(NativeProps.NAME, name);
-			quest.setProperty(NativeProps.DESC, JsonHelper.GetString(jQuest, "description", "No Description"));
-			BigItemStack tmp = HQMUtilities.HQMStackT1(JsonHelper.GetObject(jQuest, "icon"));
-			
-			if(tmp != null)
-			{
-				quest.setProperty(NativeProps.ICON, tmp);
-			} else
-			{
-				quest.setProperty(NativeProps.ICON, new BigItemStack(Items.nether_star));
-			}
-			
-			if(json.has("repeat")) // Assuming this is in Minecraft time
-			{
-				JsonObject jRpt = JsonHelper.GetObject(jQuest, "repeat");
-				int rTime = 0;
-				rTime += JsonHelper.GetNumber(jRpt, "days", 0).intValue() * 24000;
-				rTime += JsonHelper.GetNumber(jRpt, "hours", 0).intValue() * 1000;
-				quest.setProperty(NativeProps.REPEAT_TIME, rTime);
-			}
-			
-			for(JsonElement er : JsonHelper.GetArray(jQuest, "prerequisites"))
-			{
-				if(er == null || !er.isJsonPrimitive() || !er.getAsJsonPrimitive().isString())
-				{
-					continue;
-				}
-				
-				String id = er.getAsJsonPrimitive().getAsString();
-				
-				if(id.startsWith("{") && id.contains("["))
-				{
-					String[] nParts = id.split("\\[");
-					
-					if(nParts.length > 1)
-					{
-						id = nParts[1].replaceFirst("]", "");
-					}
-				}
-				
-				IQuest preReq = GetNewQuest(id, questDB);
-				addReq(quest, questDB.getID(preReq));
-			}
-			
-			for(JsonElement er : JsonHelper.GetArray(jQuest, "optionlinks"))
-			{
-				if(er == null || !er.isJsonPrimitive() || !er.getAsJsonPrimitive().isString())
-				{
-					continue;
-				}
-				
-				String id = er.getAsJsonPrimitive().getAsString();
-				
-				if(id.startsWith("{") && id.contains("["))
-				{
-					String[] nParts = id.split("\\[");
-					
-					if(nParts.length > 1)
-					{
-						id = nParts[1].replaceFirst("]", "");
-					}
-				}
-				
-				IQuest preReq = GetNewQuest(id, questDB);
-				addReq(quest, questDB.getID(preReq));
-			}
-			
-			for(JsonElement jt : JsonHelper.GetArray(jQuest, "tasks"))
-			{
-				if(jt == null || !jt.isJsonObject())
-				{
-					continue;
-				}
-				
-				JsonObject jTask = jt.getAsJsonObject();
-				String tType = JsonHelper.GetString(jTask, "type", "");
-				
-				if(tType == null || tType.length() <= 0)
-				{
-					continue;
-				} else if(!taskConverters.containsKey(tType))
-				{
-					BQ_Standard.logger.warn("Unsupported HQM task \"" + tType + "\"! Skipping...");
-					continue;
-				}
-				
-				ITask[] tsks = taskConverters.get(tType).apply(jTask);
-				
-				if(tsks != null && tsks.length > 0)
-				{
-					IDatabaseNBT<ITask, NBTTagList, NBTTagList> taskReg = quest.getTasks();
-					for(ITask t : tsks) taskReg.add(taskReg.nextID(), t);
-				}
-			}
-			
-			for(Entry<String,Function<JsonElement, IReward[]>> entry : rewardConverters.entrySet())
-			{
-				if(!jQuest.has(entry.getKey()))
-				{
-					continue;
-				}
-				
-				IReward[] rews = entry.getValue().apply(jQuest.get(entry.getKey()));
-				
-				if(rews != null && rews.length > 0)
-				{
-					IDatabaseNBT<IReward, NBTTagList, NBTTagList> rewardReg = quest.getRewards();
-					for(IReward r : rews)
-					{
-						rewardReg.add(rewardReg.nextID(), r);
-					}
-				}
-			}
-			
-			if(questLine.getValue(questDB.getID(quest)) != null)
-			{
-				BQ_Standard.logger.log(Level.WARN, "Tried to add duplicate quest " + quest + " to quest line " + questLine.getUnlocalisedName());
-			} else
-			{
-			    final int qleX = JsonHelper.GetNumber(jQuest, "x", 0).intValue();
-			    final int qleY = JsonHelper.GetNumber(jQuest, "y", 0).intValue();
-			    final boolean bigIcon = JsonHelper.GetBoolean(jQuest, "bigicon", false);
-			    
-			    IQuestLineEntry qle = questLine.createNew(questDB.getID(quest));
-			    int size = bigIcon ? 32 : 24;
-			    qle.setSize(size, size);
-			    qle.setPosition(qleX, qleY);
-			}
-		}
-	}
-    
-    private boolean containsReq(IQuest quest, int id)
-    {
-        for(int reqID : quest.getRequirements()) if(id == reqID) return true;
+        questLine.setProperty(NativeProps.DESC, JsonHelper.GetString(json, "description", "No description"));
+
+        LoadReputations(JsonHelper.GetArray(json, "reputations"));
+
+        JsonArray qlJson = JsonHelper.GetArray(json, "quests");
+
+        List<String> loadedQuests = new ArrayList<>(); // Just in case we have duplicate named quests
+
+        for (int i = 0; i < qlJson.size(); i++) {
+            JsonElement element = qlJson.get(i);
+
+            if (element == null || !element.isJsonObject()) {
+                continue;
+            }
+
+            JsonObject jQuest = element.getAsJsonObject();
+
+            String name = JsonHelper.GetString(jQuest, "name", "HQM Quest");
+            String idName = jQuest.has("uuid") ? JsonHelper.GetString(jQuest, "uuid", name) : name;
+
+            if (loadedQuests.contains(idName)) {
+                int n = 1;
+                while (loadedQuests.contains(idName + " (" + n + ")")) {
+                    n++;
+                }
+                BQ_Standard.logger.log(
+                        Level.WARN,
+                        "Found duplicate quest " + name + ". Any quests with this pre-requisite will need repair!");
+                idName = name + " (" + n + ")";
+            }
+
+            loadedQuests.add(idName);
+            IQuest quest = GetNewQuest(idName, questDB);
+
+            quest.setProperty(NativeProps.NAME, name);
+            quest.setProperty(NativeProps.DESC, JsonHelper.GetString(jQuest, "description", "No Description"));
+            BigItemStack tmp = HQMUtilities.HQMStackT1(JsonHelper.GetObject(jQuest, "icon"));
+
+            if (tmp != null) {
+                quest.setProperty(NativeProps.ICON, tmp);
+            } else {
+                quest.setProperty(NativeProps.ICON, new BigItemStack(Items.nether_star));
+            }
+
+            if (json.has("repeat")) // Assuming this is in Minecraft time
+            {
+                JsonObject jRpt = JsonHelper.GetObject(jQuest, "repeat");
+                int rTime = 0;
+                rTime += JsonHelper.GetNumber(jRpt, "days", 0).intValue() * 24000;
+                rTime += JsonHelper.GetNumber(jRpt, "hours", 0).intValue() * 1000;
+                quest.setProperty(NativeProps.REPEAT_TIME, rTime);
+            }
+
+            for (JsonElement er : JsonHelper.GetArray(jQuest, "prerequisites")) {
+                if (er == null
+                        || !er.isJsonPrimitive()
+                        || !er.getAsJsonPrimitive().isString()) {
+                    continue;
+                }
+
+                String id = er.getAsJsonPrimitive().getAsString();
+
+                if (id.startsWith("{") && id.contains("[")) {
+                    String[] nParts = id.split("\\[");
+
+                    if (nParts.length > 1) {
+                        id = nParts[1].replaceFirst("]", "");
+                    }
+                }
+
+                IQuest preReq = GetNewQuest(id, questDB);
+                addReq(quest, questDB.getID(preReq));
+            }
+
+            for (JsonElement er : JsonHelper.GetArray(jQuest, "optionlinks")) {
+                if (er == null
+                        || !er.isJsonPrimitive()
+                        || !er.getAsJsonPrimitive().isString()) {
+                    continue;
+                }
+
+                String id = er.getAsJsonPrimitive().getAsString();
+
+                if (id.startsWith("{") && id.contains("[")) {
+                    String[] nParts = id.split("\\[");
+
+                    if (nParts.length > 1) {
+                        id = nParts[1].replaceFirst("]", "");
+                    }
+                }
+
+                IQuest preReq = GetNewQuest(id, questDB);
+                addReq(quest, questDB.getID(preReq));
+            }
+
+            for (JsonElement jt : JsonHelper.GetArray(jQuest, "tasks")) {
+                if (jt == null || !jt.isJsonObject()) {
+                    continue;
+                }
+
+                JsonObject jTask = jt.getAsJsonObject();
+                String tType = JsonHelper.GetString(jTask, "type", "");
+
+                if (tType == null || tType.length() <= 0) {
+                    continue;
+                } else if (!taskConverters.containsKey(tType)) {
+                    BQ_Standard.logger.warn("Unsupported HQM task \"" + tType + "\"! Skipping...");
+                    continue;
+                }
+
+                ITask[] tsks = taskConverters.get(tType).apply(jTask);
+
+                if (tsks != null && tsks.length > 0) {
+                    IDatabaseNBT<ITask, NBTTagList, NBTTagList> taskReg = quest.getTasks();
+                    for (ITask t : tsks) taskReg.add(taskReg.nextID(), t);
+                }
+            }
+
+            for (Entry<String, Function<JsonElement, IReward[]>> entry : rewardConverters.entrySet()) {
+                if (!jQuest.has(entry.getKey())) {
+                    continue;
+                }
+
+                IReward[] rews = entry.getValue().apply(jQuest.get(entry.getKey()));
+
+                if (rews != null && rews.length > 0) {
+                    IDatabaseNBT<IReward, NBTTagList, NBTTagList> rewardReg = quest.getRewards();
+                    for (IReward r : rews) {
+                        rewardReg.add(rewardReg.nextID(), r);
+                    }
+                }
+            }
+
+            if (questLine.getValue(questDB.getID(quest)) != null) {
+                BQ_Standard.logger.log(
+                        Level.WARN,
+                        "Tried to add duplicate quest " + quest + " to quest line " + questLine.getUnlocalisedName());
+            } else {
+                final int qleX = JsonHelper.GetNumber(jQuest, "x", 0).intValue();
+                final int qleY = JsonHelper.GetNumber(jQuest, "y", 0).intValue();
+                final boolean bigIcon = JsonHelper.GetBoolean(jQuest, "bigicon", false);
+
+                IQuestLineEntry qle = questLine.createNew(questDB.getID(quest));
+                int size = bigIcon ? 32 : 24;
+                qle.setSize(size, size);
+                qle.setPosition(qleX, qleY);
+            }
+        }
+    }
+
+    private boolean containsReq(IQuest quest, int id) {
+        for (int reqID : quest.getRequirements()) if (id == reqID) return true;
         return false;
     }
-    
-    private void addReq(IQuest quest, int id)
-    {
-        if(containsReq(quest, id)) return;
+
+    private void addReq(IQuest quest, int id) {
+        if (containsReq(quest, id)) return;
         int[] orig = quest.getRequirements();
         int[] added = Arrays.copyOf(orig, orig.length + 1);
         added[orig.length] = id;
         quest.setRequirements(added);
     }
-	
-	static
-	{
-		taskConverters.put("DETECT", new HQMTaskDetect(false)::convertTask);
-		taskConverters.put("CONSUME", new HQMTaskDetect(true)::convertTask);
-		taskConverters.put("CONSUME_QDS", new HQMTaskDetect(true)::convertTask);
-		taskConverters.put("KILL", new HQMTaskKill()::convertTask);
-		taskConverters.put("LOCATION", new HQMTaskLocation()::convertTask);
-		taskConverters.put("CRAFT", new HQMTaskCraft()::convertTask);
-		taskConverters.put("BLOCK_BREAK", new HQMTaskBlockBreak()::convertTask);
-		taskConverters.put("BLOCK_PLACE", new HQMTaskBlockPlace()::convertTask);
-		taskConverters.put("REPUTATION", new HQMTaskReputaion()::convertTask);
-		
-		rewardConverters.put("reward", new HQMRewardStandard()::convertReward);
-		rewardConverters.put("rewardchoice", new HQMRewardChoice()::convertReward);
-		rewardConverters.put("reputationrewards", new HQMRewardReputation()::convertReward);
-		rewardConverters.put("commandrewards", new HQMRewardCommand()::convertReward);
-	}
+
+    static {
+        taskConverters.put("DETECT", new HQMTaskDetect(false)::convertTask);
+        taskConverters.put("CONSUME", new HQMTaskDetect(true)::convertTask);
+        taskConverters.put("CONSUME_QDS", new HQMTaskDetect(true)::convertTask);
+        taskConverters.put("KILL", new HQMTaskKill()::convertTask);
+        taskConverters.put("LOCATION", new HQMTaskLocation()::convertTask);
+        taskConverters.put("CRAFT", new HQMTaskCraft()::convertTask);
+        taskConverters.put("BLOCK_BREAK", new HQMTaskBlockBreak()::convertTask);
+        taskConverters.put("BLOCK_PLACE", new HQMTaskBlockPlace()::convertTask);
+        taskConverters.put("REPUTATION", new HQMTaskReputaion()::convertTask);
+
+        rewardConverters.put("reward", new HQMRewardStandard()::convertReward);
+        rewardConverters.put("rewardchoice", new HQMRewardChoice()::convertReward);
+        rewardConverters.put("reputationrewards", new HQMRewardReputation()::convertReward);
+        rewardConverters.put("commandrewards", new HQMRewardCommand()::convertReward);
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/HQMUtilities.java
+++ b/src/main/java/bq_standard/importers/hqm/HQMUtilities.java
@@ -8,6 +8,7 @@ import bq_standard.importers.hqm.converters.items.HQMItem;
 import bq_standard.importers.hqm.converters.items.HQMItemBag;
 import bq_standard.importers.hqm.converters.items.HQMItemHeart;
 import com.google.gson.JsonObject;
+import java.util.HashMap;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTTagCompound;
@@ -17,115 +18,113 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 import org.apache.logging.log4j.Level;
 
-import java.util.HashMap;
+public class HQMUtilities {
+    /**
+     * Get HQM formatted item, Type 1
+     */
+    public static BigItemStack HQMStackT1(
+            JsonObject json) // This can return multiple stacks in the event the stack size exceeds 127
+            {
+        String iID = JsonHelper.GetString(json, "id", "minecraft:stone");
+        Item item = (Item) Item.itemRegistry.getObject(iID);
+        int amount = JsonHelper.GetNumber(json, "amount", 1).intValue();
+        int damage = JsonHelper.GetNumber(json, "damage", 0).intValue();
+        NBTTagCompound tags = null;
 
-public class HQMUtilities
-{
-	/**
-	 * Get HQM formatted item, Type 1
-	 */
-	public static BigItemStack HQMStackT1(JsonObject json) // This can return multiple stacks in the event the stack size exceeds 127
-	{
-		String iID = JsonHelper.GetString(json, "id", "minecraft:stone");
-		Item item = (Item)Item.itemRegistry.getObject(iID);
-		int amount = JsonHelper.GetNumber(json, "amount", 1).intValue();
-		int damage = JsonHelper.GetNumber(json, "damage", 0).intValue();
-		NBTTagCompound tags = null;
-		
-		if(json.has("nbt"))
-		{
-			try
-			{
-				String rawNbt = json.get("nbt").toString(); // Must use this method. Gson formatting will damage it otherwise
-				
-				// Hack job to fix backslashes (why are 2 Json formats being used in HQM?!)
-				rawNbt = rawNbt.replaceFirst("\"", ""); // Delete first quote
-				rawNbt = rawNbt.substring(0, rawNbt.length() - 1); // Delete last quote
-				rawNbt = rawNbt.replace(":\\\"", ":\""); // Fix start of strings
-				rawNbt = rawNbt.replace("\\\",", "\","); // Fix middle of lists
-				rawNbt = rawNbt.replace("\\\"}", "\"}"); // Fix end of strings
-				rawNbt = rawNbt.replace("\\\"]", "\"]"); // Fix end of lists
-				rawNbt = rawNbt.replace("[\\\"", "[\""); // Fix start of lists
-				rawNbt = rawNbt.replace("\\n", "\n");
-				
-				tags = (NBTTagCompound)JsonToNBT.func_150315_a(rawNbt);
-			} catch(Exception e)
-			{
-				BQ_Standard.logger.log(Level.ERROR, "Unable to convert HQM NBT data. This is likely a HQM Gson/Json formatting issue", e);
-			}
-		}
-		
-		HQMItem hqm = itemConverters.get(iID.toLowerCase());
-		if(hqm != null) return hqm.convertItem(damage, amount, tags);
-		
-		return PlaceholderConverter.convertItem(item, iID, amount, damage, "", tags);
-	}
-	
-	/**
-	 * Get HQM formatted item, Type 2
-	 */
-	public static BigItemStack HQMStackT2(JsonObject rJson) // This can return multiple stacks in the event the stack size exceeds 127
-	{
-		JsonObject json = JsonHelper.GetObject(rJson, "item");
-		String iID = JsonHelper.GetString(json, "id", "minecraft:stone");
-		Item item = (Item)Item.itemRegistry.getObject(iID);
-		int amount = JsonHelper.GetNumber(rJson, "required", 1).intValue();
-		int damage = JsonHelper.GetNumber(json, "damage", 0).intValue();
-		boolean oreDict = JsonHelper.GetString(rJson, "precision", "").equalsIgnoreCase("ORE_DICTIONARY");
-		
-		NBTTagCompound tags = null;
-		
-		if(json.has("nbt"))
-		{
-			try
-			{
-				String rawNbt = json.get("nbt").toString(); // Must use this method. Gson formatting will damage it otherwise
-				
-				// Hack job to fix backslashes (why are 2 Json formats being used in HQM?!)
-				rawNbt = rawNbt.replaceFirst("\"", ""); // Delete first quote
-				rawNbt = rawNbt.substring(0, rawNbt.length() - 1); // Delete last quote
-				rawNbt = rawNbt.replace(":\\\"", ":\""); // Fix start of strings
-				rawNbt = rawNbt.replace("\\\",", "\","); // Fix middle of lists
-				rawNbt = rawNbt.replace("\\\"}", "\"}"); // Fix end of strings
-				rawNbt = rawNbt.replace("\\\"]", "\"]"); // Fix end of lists
-				rawNbt = rawNbt.replace("[\\\"", "[\""); // Fix start of lists
-				rawNbt = rawNbt.replace("\\n", "\n");
-				
-				tags = (NBTTagCompound)JsonToNBT.func_150315_a(rawNbt);
-			} catch(Exception e)
-			{
-				BQ_Standard.logger.log(Level.ERROR, "Unable to convert HQM NBT data. This is likely a HQM Gson/Json formatting issue", e);
-			}
-		}
-		
-		HQMItem hqm = itemConverters.get(iID.toLowerCase());
-		if(hqm != null) return hqm.convertItem(damage, amount, tags);
-		
-		BigItemStack stack = PlaceholderConverter.convertItem(item, iID, amount, damage, "", tags);
-		
-		if(oreDict && item != null)
-		{
-			int[] oreId = OreDictionary.getOreIDs(stack.getBaseStack());
-			if(oreId.length > 0) stack.setOreDict(OreDictionary.getOreName(oreId[0]));
-		}
-		
-		return stack;
-	}
-	
-	public static FluidStack HQMStackT3(JsonObject json)
-	{
-		String name = JsonHelper.GetString(json, "fluid", "water");
-		Fluid fluid = FluidRegistry.getFluid(name);
-		int amount = JsonHelper.GetNumber(json, "required", 1000).intValue();
-        
+        if (json.has("nbt")) {
+            try {
+                String rawNbt =
+                        json.get("nbt").toString(); // Must use this method. Gson formatting will damage it otherwise
+
+                // Hack job to fix backslashes (why are 2 Json formats being used in HQM?!)
+                rawNbt = rawNbt.replaceFirst("\"", ""); // Delete first quote
+                rawNbt = rawNbt.substring(0, rawNbt.length() - 1); // Delete last quote
+                rawNbt = rawNbt.replace(":\\\"", ":\""); // Fix start of strings
+                rawNbt = rawNbt.replace("\\\",", "\","); // Fix middle of lists
+                rawNbt = rawNbt.replace("\\\"}", "\"}"); // Fix end of strings
+                rawNbt = rawNbt.replace("\\\"]", "\"]"); // Fix end of lists
+                rawNbt = rawNbt.replace("[\\\"", "[\""); // Fix start of lists
+                rawNbt = rawNbt.replace("\\n", "\n");
+
+                tags = (NBTTagCompound) JsonToNBT.func_150315_a(rawNbt);
+            } catch (Exception e) {
+                BQ_Standard.logger.log(
+                        Level.ERROR,
+                        "Unable to convert HQM NBT data. This is likely a HQM Gson/Json formatting issue",
+                        e);
+            }
+        }
+
+        HQMItem hqm = itemConverters.get(iID.toLowerCase());
+        if (hqm != null) return hqm.convertItem(damage, amount, tags);
+
+        return PlaceholderConverter.convertItem(item, iID, amount, damage, "", tags);
+    }
+
+    /**
+     * Get HQM formatted item, Type 2
+     */
+    public static BigItemStack HQMStackT2(
+            JsonObject rJson) // This can return multiple stacks in the event the stack size exceeds 127
+            {
+        JsonObject json = JsonHelper.GetObject(rJson, "item");
+        String iID = JsonHelper.GetString(json, "id", "minecraft:stone");
+        Item item = (Item) Item.itemRegistry.getObject(iID);
+        int amount = JsonHelper.GetNumber(rJson, "required", 1).intValue();
+        int damage = JsonHelper.GetNumber(json, "damage", 0).intValue();
+        boolean oreDict = JsonHelper.GetString(rJson, "precision", "").equalsIgnoreCase("ORE_DICTIONARY");
+
+        NBTTagCompound tags = null;
+
+        if (json.has("nbt")) {
+            try {
+                String rawNbt =
+                        json.get("nbt").toString(); // Must use this method. Gson formatting will damage it otherwise
+
+                // Hack job to fix backslashes (why are 2 Json formats being used in HQM?!)
+                rawNbt = rawNbt.replaceFirst("\"", ""); // Delete first quote
+                rawNbt = rawNbt.substring(0, rawNbt.length() - 1); // Delete last quote
+                rawNbt = rawNbt.replace(":\\\"", ":\""); // Fix start of strings
+                rawNbt = rawNbt.replace("\\\",", "\","); // Fix middle of lists
+                rawNbt = rawNbt.replace("\\\"}", "\"}"); // Fix end of strings
+                rawNbt = rawNbt.replace("\\\"]", "\"]"); // Fix end of lists
+                rawNbt = rawNbt.replace("[\\\"", "[\""); // Fix start of lists
+                rawNbt = rawNbt.replace("\\n", "\n");
+
+                tags = (NBTTagCompound) JsonToNBT.func_150315_a(rawNbt);
+            } catch (Exception e) {
+                BQ_Standard.logger.log(
+                        Level.ERROR,
+                        "Unable to convert HQM NBT data. This is likely a HQM Gson/Json formatting issue",
+                        e);
+            }
+        }
+
+        HQMItem hqm = itemConverters.get(iID.toLowerCase());
+        if (hqm != null) return hqm.convertItem(damage, amount, tags);
+
+        BigItemStack stack = PlaceholderConverter.convertItem(item, iID, amount, damage, "", tags);
+
+        if (oreDict && item != null) {
+            int[] oreId = OreDictionary.getOreIDs(stack.getBaseStack());
+            if (oreId.length > 0) stack.setOreDict(OreDictionary.getOreName(oreId[0]));
+        }
+
+        return stack;
+    }
+
+    public static FluidStack HQMStackT3(JsonObject json) {
+        String name = JsonHelper.GetString(json, "fluid", "water");
+        Fluid fluid = FluidRegistry.getFluid(name);
+        int amount = JsonHelper.GetNumber(json, "required", 1000).intValue();
+
         return PlaceholderConverter.convertFluid(fluid, name, amount, null);
-	}
-	
-	private static HashMap<String,HQMItem> itemConverters = new HashMap<>();
-	
-	static
-	{
-		itemConverters.put("hardcorequesting:hearts", new HQMItemHeart());
-		itemConverters.put("hardcorequesting:bags", new HQMItemBag());
-	}
+    }
+
+    private static HashMap<String, HQMItem> itemConverters = new HashMap<>();
+
+    static {
+        itemConverters.put("hardcorequesting:hearts", new HQMItemHeart());
+        itemConverters.put("hardcorequesting:bags", new HQMItemBag());
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/HQMRep.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/HQMRep.java
@@ -2,24 +2,20 @@ package bq_standard.importers.hqm.converters;
 
 import java.util.HashMap;
 
-public class HQMRep
-{
+public class HQMRep {
     public final String rName;
-    
+
     private final HashMap<Integer, Integer> markerList = new HashMap<>();
-    
-    public HQMRep(String name)
-    {
+
+    public HQMRep(String name) {
         this.rName = name;
     }
-    
-    public void addMarker(int id, int value)
-    {
+
+    public void addMarker(int id, int value) {
         markerList.put(id, value);
     }
-    
-    public int getMarker(int id)
-    {
+
+    public int getMarker(int id) {
         Integer i = markerList.get(id);
         return i == null ? 0 : i;
     }

--- a/src/main/java/bq_standard/importers/hqm/converters/items/HQMItem.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/items/HQMItem.java
@@ -3,7 +3,6 @@ package bq_standard.importers.hqm.converters.items;
 import betterquesting.api.utils.BigItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-public interface HQMItem
-{
-	BigItemStack convertItem(int damage, int amount, NBTTagCompound tags);
+public interface HQMItem {
+    BigItemStack convertItem(int damage, int amount, NBTTagCompound tags);
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/items/HQMItemBag.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/items/HQMItemBag.java
@@ -4,11 +4,9 @@ import betterquesting.api.utils.BigItemStack;
 import bq_standard.core.BQ_Standard;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class HQMItemBag implements HQMItem
-{
-	@Override
-	public BigItemStack convertItem(int damage, int amount, NBTTagCompound tags)
-	{
-		return new BigItemStack(BQ_Standard.lootChest, amount, damage * 25);
-	}
+public class HQMItemBag implements HQMItem {
+    @Override
+    public BigItemStack convertItem(int damage, int amount, NBTTagCompound tags) {
+        return new BigItemStack(BQ_Standard.lootChest, amount, damage * 25);
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/items/HQMItemHeart.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/items/HQMItemHeart.java
@@ -4,35 +4,31 @@ import betterquesting.api.utils.BigItemStack;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class HQMItemHeart implements HQMItem
-{
-	private final Item bqHeart;
-	
-	public HQMItemHeart()
-	{
-		bqHeart = (Item)Item.itemRegistry.getObject("betterquesting:extra_life");
-	}
-	
-	@Override
-	public BigItemStack convertItem(int damage, int amount, NBTTagCompound tags)
-	{
-		int amt = amount;
-		int dmg = 0;
-		
-		switch(damage)
-		{
-			case 0:
-				dmg = 2;
-				break;
-			case 1:
-				dmg = 1;
-				break;
-			case 2:
-				dmg = 2;
-				amt *= 3;
-				break;
-		}
-		
-		return new BigItemStack(bqHeart, amt, dmg);
-	}
+public class HQMItemHeart implements HQMItem {
+    private final Item bqHeart;
+
+    public HQMItemHeart() {
+        bqHeart = (Item) Item.itemRegistry.getObject("betterquesting:extra_life");
+    }
+
+    @Override
+    public BigItemStack convertItem(int damage, int amount, NBTTagCompound tags) {
+        int amt = amount;
+        int dmg = 0;
+
+        switch (damage) {
+            case 0:
+                dmg = 2;
+                break;
+            case 1:
+                dmg = 1;
+                break;
+            case 2:
+                dmg = 2;
+                amt *= 3;
+                break;
+        }
+
+        return new BigItemStack(bqHeart, amt, dmg);
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/rewards/HQMRewardChoice.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/rewards/HQMRewardChoice.java
@@ -7,20 +7,16 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-public class HQMRewardChoice
-{
-	public IReward[] convertReward(JsonElement json)
-	{
-		if(!(json instanceof JsonArray)) return null;
-		
-		RewardChoice reward = new RewardChoice();
-		for(JsonElement je : json.getAsJsonArray())
-		{
-			if(!(je instanceof JsonObject)) continue;
-			reward.choices.add(HQMUtilities.HQMStackT1(je.getAsJsonObject()));
-		}
-		
-		return new IReward[]{reward};
-	}
-	
+public class HQMRewardChoice {
+    public IReward[] convertReward(JsonElement json) {
+        if (!(json instanceof JsonArray)) return null;
+
+        RewardChoice reward = new RewardChoice();
+        for (JsonElement je : json.getAsJsonArray()) {
+            if (!(je instanceof JsonObject)) continue;
+            reward.choices.add(HQMUtilities.HQMStackT1(je.getAsJsonObject()));
+        }
+
+        return new IReward[] {reward};
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/rewards/HQMRewardCommand.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/rewards/HQMRewardCommand.java
@@ -5,28 +5,24 @@ import bq_standard.rewards.RewardCommand;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class HQMRewardCommand
-{
-	public IReward[] convertReward(JsonElement json)
-	{
-		if(!(json instanceof JsonArray)) return null;
-		
-		List<IReward> rList = new ArrayList<>();
-		
-		for(JsonElement je : json.getAsJsonArray())
-		{
-			if(!(je instanceof JsonPrimitive)) continue;
-			RewardCommand reward = new RewardCommand();
-			reward.command = je.getAsString();
-			reward.viaPlayer = true;
-			reward.hideCmd = true;
-			rList.add(reward);
-		}
-		
-		return rList.toArray(new IReward[0]);
-	}
+public class HQMRewardCommand {
+    public IReward[] convertReward(JsonElement json) {
+        if (!(json instanceof JsonArray)) return null;
+
+        List<IReward> rList = new ArrayList<>();
+
+        for (JsonElement je : json.getAsJsonArray()) {
+            if (!(je instanceof JsonPrimitive)) continue;
+            RewardCommand reward = new RewardCommand();
+            reward.command = je.getAsString();
+            reward.viaPlayer = true;
+            reward.hideCmd = true;
+            rList.add(reward);
+        }
+
+        return rList.toArray(new IReward[0]);
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/rewards/HQMRewardReputation.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/rewards/HQMRewardReputation.java
@@ -8,43 +8,37 @@ import bq_standard.rewards.RewardScoreboard;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class HQMRewardReputation
-{
-	public IReward[] convertReward(JsonElement json)
-	{
-		if(!(json instanceof JsonArray)) return null;
-		List<IReward> rList = new ArrayList<>();
-		
-		for(JsonElement je : json.getAsJsonArray())
-		{
-			if(!(je instanceof JsonObject)) continue;
-			JsonObject jRep = je.getAsJsonObject();
-			
-			JsonElement jid = jRep.get("reputation");
-			if(jid == null || !jid.isJsonPrimitive()) continue;
-			
-			String repId;
-			if(jid.getAsJsonPrimitive().isString())
-            {
+public class HQMRewardReputation {
+    public IReward[] convertReward(JsonElement json) {
+        if (!(json instanceof JsonArray)) return null;
+        List<IReward> rList = new ArrayList<>();
+
+        for (JsonElement je : json.getAsJsonArray()) {
+            if (!(je instanceof JsonObject)) continue;
+            JsonObject jRep = je.getAsJsonObject();
+
+            JsonElement jid = jRep.get("reputation");
+            if (jid == null || !jid.isJsonPrimitive()) continue;
+
+            String repId;
+            if (jid.getAsJsonPrimitive().isString()) {
                 repId = JsonHelper.GetString(jRep, "reputation", "");
-            } else
-            {
+            } else {
                 repId = JsonHelper.GetNumber(jRep, "reputation", 0).toString();
             }
-            
-			HQMRep repObj = HQMQuestImporter.INSTANCE.reputations.get(repId);
-			if(repObj == null) continue;
-			
-			RewardScoreboard reward = new RewardScoreboard();
-			reward.score = repObj.rName;
-			reward.value = JsonHelper.GetNumber(jRep, "value", 1).intValue();
-			rList.add(reward);
-		}
-		
-		return rList.toArray(new IReward[0]);
-	}
+
+            HQMRep repObj = HQMQuestImporter.INSTANCE.reputations.get(repId);
+            if (repObj == null) continue;
+
+            RewardScoreboard reward = new RewardScoreboard();
+            reward.score = repObj.rName;
+            reward.value = JsonHelper.GetNumber(jRep, "value", 1).intValue();
+            rList.add(reward);
+        }
+
+        return rList.toArray(new IReward[0]);
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/rewards/HQMRewardStandard.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/rewards/HQMRewardStandard.java
@@ -7,19 +7,16 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-public class HQMRewardStandard
-{
-	public IReward[] convertReward(JsonElement json)
-	{
-		if(!(json instanceof JsonArray)) return null;
-		
-		RewardItem reward = new RewardItem();
-		for(JsonElement je : json.getAsJsonArray())
-		{
-			if(!(je instanceof JsonObject)) continue;
-			reward.items.add(HQMUtilities.HQMStackT1(je.getAsJsonObject()));
-		}
-		
-		return new IReward[]{reward};
-	}
+public class HQMRewardStandard {
+    public IReward[] convertReward(JsonElement json) {
+        if (!(json instanceof JsonArray)) return null;
+
+        RewardItem reward = new RewardItem();
+        for (JsonElement je : json.getAsJsonArray()) {
+            if (!(je instanceof JsonObject)) continue;
+            reward.items.add(HQMUtilities.HQMStackT1(je.getAsJsonObject()));
+        }
+
+        return new IReward[] {reward};
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskBlockBreak.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskBlockBreak.java
@@ -10,26 +10,24 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemBlock;
 
-public class HQMTaskBlockBreak
-{
-    public ITask[] convertTask(JsonObject json)
-    {
+public class HQMTaskBlockBreak {
+    public ITask[] convertTask(JsonObject json) {
         TaskBlockBreak taskBreak = new TaskBlockBreak();
-        
-        for(JsonElement je2 : JsonHelper.GetArray(json, "blocks"))
-        {
-            if(!(je2 instanceof JsonObject)) continue;
+
+        for (JsonElement je2 : JsonHelper.GetArray(json, "blocks")) {
+            if (!(je2 instanceof JsonObject)) continue;
             JsonObject jBlock = je2.getAsJsonObject();
             BigItemStack stack = HQMUtilities.HQMStackT1(JsonHelper.GetObject(jBlock, "item"));
-            if(!(stack.getBaseStack().getItem() instanceof ItemBlock)) continue; // Lazy conversion. Too much effort to handle all the edge cases
-            ItemBlock iBlock = (ItemBlock)stack.getBaseStack().getItem();
+            if (!(stack.getBaseStack().getItem() instanceof ItemBlock))
+                continue; // Lazy conversion. Too much effort to handle all the edge cases
+            ItemBlock iBlock = (ItemBlock) stack.getBaseStack().getItem();
             NbtBlockType blockType = new NbtBlockType();
             blockType.b = iBlock.field_150939_a;
             blockType.m = stack.getBaseStack().getItemDamage();
             blockType.n = JsonHelper.GetNumber(jBlock, "required", 1).intValue();
             taskBreak.blockTypes.add(blockType);
         }
-        
-        return new ITask[]{taskBreak};
+
+        return new ITask[] {taskBreak};
     }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskBlockPlace.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskBlockPlace.java
@@ -7,29 +7,25 @@ import bq_standard.importers.hqm.HQMUtilities;
 import bq_standard.tasks.TaskInteractItem;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import net.minecraft.nbt.NBTTagCompound;
-
 import java.util.ArrayList;
 import java.util.List;
+import net.minecraft.nbt.NBTTagCompound;
 
-public class HQMTaskBlockPlace
-{
-    public ITask[] convertTask(JsonObject json)
-    {
-		List<ITask> tList = new ArrayList<>();
-		
-		for(JsonElement je : JsonHelper.GetArray(json, "blocks"))
-		{
-            if(!(je instanceof JsonObject)) continue;
-			JsonObject jObj = je.getAsJsonObject();
-			
-			TaskInteractItem task = new TaskInteractItem();
+public class HQMTaskBlockPlace {
+    public ITask[] convertTask(JsonObject json) {
+        List<ITask> tList = new ArrayList<>();
+
+        for (JsonElement je : JsonHelper.GetArray(json, "blocks")) {
+            if (!(je instanceof JsonObject)) continue;
+            JsonObject jObj = je.getAsJsonObject();
+
+            TaskInteractItem task = new TaskInteractItem();
             BigItemStack stack = HQMUtilities.HQMStackT1(JsonHelper.GetObject(jObj, "item"));
             task.targetItem.readFromNBT(stack.writeToNBT(new NBTTagCompound()));
             task.required = JsonHelper.GetNumber(jObj, "required", 1).intValue();
-			tList.add(task);
-		}
-		
-		return tList.toArray(new ITask[0]);
+            tList.add(task);
+        }
+
+        return tList.toArray(new ITask[0]);
     }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskCraft.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskCraft.java
@@ -7,18 +7,15 @@ import bq_standard.tasks.TaskCrafting;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-public class HQMTaskCraft
-{
-	public ITask[] convertTask(JsonObject json)
-	{
-		TaskCrafting task = new TaskCrafting();
-		
-		for(JsonElement element : JsonHelper.GetArray(json, "items"))
-		{
-			if(!(element instanceof JsonObject)) continue;
-			task.requiredItems.add(HQMUtilities.HQMStackT2(element.getAsJsonObject()));
-		}
-		
-		return new ITask[]{task};
-	}
+public class HQMTaskCraft {
+    public ITask[] convertTask(JsonObject json) {
+        TaskCrafting task = new TaskCrafting();
+
+        for (JsonElement element : JsonHelper.GetArray(json, "items")) {
+            if (!(element instanceof JsonObject)) continue;
+            task.requiredItems.add(HQMUtilities.HQMStackT2(element.getAsJsonObject()));
+        }
+
+        return new ITask[] {task};
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskDetect.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskDetect.java
@@ -7,45 +7,38 @@ import bq_standard.tasks.TaskFluid;
 import bq_standard.tasks.TaskRetrieval;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class HQMTaskDetect
-{
-	private final boolean consume;
-	
-	public HQMTaskDetect(boolean consume)
-	{
-		this.consume = consume;
-	}
-	
-	public ITask[] convertTask(JsonObject json)
-	{
-		List<ITask> tList = new ArrayList<>();
-		TaskRetrieval retTask = new TaskRetrieval();
-		TaskFluid fluTask = new TaskFluid();
-		
-		retTask.consume = this.consume;
-		
-		for(JsonElement je : JsonHelper.GetArray(json, "items"))
-		{
-			if(!(je instanceof JsonObject)) continue;
-			JsonObject ji = je.getAsJsonObject();
-			
-			if(ji.has("fluid"))
-			{
-				fluTask.requiredFluids.add(HQMUtilities.HQMStackT3(ji));
-			} else
-			{
-				retTask.requiredItems.add(HQMUtilities.HQMStackT2(ji));
-			}
-		}
-		
-		if(retTask.requiredItems.size() > 0) tList.add(retTask);
-		
-		if(fluTask.requiredFluids.size() > 0) tList.add(fluTask);
-		
-		return tList.toArray(new ITask[0]);
-	}
+public class HQMTaskDetect {
+    private final boolean consume;
+
+    public HQMTaskDetect(boolean consume) {
+        this.consume = consume;
+    }
+
+    public ITask[] convertTask(JsonObject json) {
+        List<ITask> tList = new ArrayList<>();
+        TaskRetrieval retTask = new TaskRetrieval();
+        TaskFluid fluTask = new TaskFluid();
+
+        retTask.consume = this.consume;
+
+        for (JsonElement je : JsonHelper.GetArray(json, "items")) {
+            if (!(je instanceof JsonObject)) continue;
+            JsonObject ji = je.getAsJsonObject();
+
+            if (ji.has("fluid")) {
+                fluTask.requiredFluids.add(HQMUtilities.HQMStackT3(ji));
+            } else {
+                retTask.requiredItems.add(HQMUtilities.HQMStackT2(ji));
+            }
+        }
+
+        if (retTask.requiredItems.size() > 0) tList.add(retTask);
+
+        if (fluTask.requiredFluids.size() > 0) tList.add(fluTask);
+
+        return tList.toArray(new ITask[0]);
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskKill.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskKill.java
@@ -5,28 +5,24 @@ import betterquesting.api.utils.JsonHelper;
 import bq_standard.tasks.TaskHunt;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class HQMTaskKill
-{
-	public ITask[] convertTask(JsonObject json)
-	{
-		List<ITask> tList = new ArrayList<>();
-		
-		for(JsonElement je : JsonHelper.GetArray(json, "mobs"))
-		{
-			if(!(je instanceof JsonObject)) continue;
-			JsonObject jMob = je.getAsJsonObject();
-			
-			TaskHunt task = new TaskHunt();
-			task.idName = JsonHelper.GetString(jMob, "mob", "minecraft:zombie");
-			task.required = JsonHelper.GetNumber(jMob, "kills", 1).intValue();
-			task.subtypes = !JsonHelper.GetBoolean(jMob, "exact", false);
-			tList.add(task);
-		}
-		
-		return tList.toArray(new ITask[0]);
-	}
+public class HQMTaskKill {
+    public ITask[] convertTask(JsonObject json) {
+        List<ITask> tList = new ArrayList<>();
+
+        for (JsonElement je : JsonHelper.GetArray(json, "mobs")) {
+            if (!(je instanceof JsonObject)) continue;
+            JsonObject jMob = je.getAsJsonObject();
+
+            TaskHunt task = new TaskHunt();
+            task.idName = JsonHelper.GetString(jMob, "mob", "minecraft:zombie");
+            task.required = JsonHelper.GetNumber(jMob, "kills", 1).intValue();
+            task.subtypes = !JsonHelper.GetBoolean(jMob, "exact", false);
+            tList.add(task);
+        }
+
+        return tList.toArray(new ITask[0]);
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskLocation.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskLocation.java
@@ -5,32 +5,28 @@ import betterquesting.api.utils.JsonHelper;
 import bq_standard.tasks.TaskLocation;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class HQMTaskLocation
-{
-	public ITask[] convertTask(JsonObject json)
-	{
-		List<ITask> tList = new ArrayList<>();
-		
-		for(JsonElement element : JsonHelper.GetArray(json, "locations"))
-		{
-			if(!(element instanceof JsonObject)) continue;
-			JsonObject jLoc = element.getAsJsonObject();
-			
-			TaskLocation task = new TaskLocation();
-			task.name = JsonHelper.GetString(jLoc, "name", "New Location");
-			task.x = JsonHelper.GetNumber(jLoc, "posX", 0).intValue();
-			task.y = JsonHelper.GetNumber(jLoc, "posY", 0).intValue();
-			task.z = JsonHelper.GetNumber(jLoc, "posZ", 0).intValue();
-			task.dim = JsonHelper.GetNumber(jLoc, "dim", 0).intValue();
-			task.range = JsonHelper.GetNumber(jLoc, "radius", -1).intValue();
-			task.hideInfo = JsonHelper.GetString(jLoc, "", "").equalsIgnoreCase("NONE");
-			tList.add(task);
-		}
-		
-		return tList.toArray(new ITask[0]);
-	}
+public class HQMTaskLocation {
+    public ITask[] convertTask(JsonObject json) {
+        List<ITask> tList = new ArrayList<>();
+
+        for (JsonElement element : JsonHelper.GetArray(json, "locations")) {
+            if (!(element instanceof JsonObject)) continue;
+            JsonObject jLoc = element.getAsJsonObject();
+
+            TaskLocation task = new TaskLocation();
+            task.name = JsonHelper.GetString(jLoc, "name", "New Location");
+            task.x = JsonHelper.GetNumber(jLoc, "posX", 0).intValue();
+            task.y = JsonHelper.GetNumber(jLoc, "posY", 0).intValue();
+            task.z = JsonHelper.GetNumber(jLoc, "posZ", 0).intValue();
+            task.dim = JsonHelper.GetNumber(jLoc, "dim", 0).intValue();
+            task.range = JsonHelper.GetNumber(jLoc, "radius", -1).intValue();
+            task.hideInfo = JsonHelper.GetString(jLoc, "", "").equalsIgnoreCase("NONE");
+            tList.add(task);
+        }
+
+        return tList.toArray(new ITask[0]);
+    }
 }

--- a/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskReputaion.java
+++ b/src/main/java/bq_standard/importers/hqm/converters/tasks/HQMTaskReputaion.java
@@ -8,57 +8,49 @@ import bq_standard.tasks.TaskScoreboard;
 import bq_standard.tasks.TaskScoreboard.ScoreOperation;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class HQMTaskReputaion
-{
-    public ITask[] convertTask(JsonObject json)
-    {
+public class HQMTaskReputaion {
+    public ITask[] convertTask(JsonObject json) {
         List<ITask> tasks = new ArrayList<>();
-        
-        for(JsonElement je : JsonHelper.GetArray(json, "reputation"))
-        {
-            if(!(je instanceof JsonObject)) continue;
+
+        for (JsonElement je : JsonHelper.GetArray(json, "reputation")) {
+            if (!(je instanceof JsonObject)) continue;
             JsonObject jRep = je.getAsJsonObject();
-            
+
             String repId;
             JsonElement jid = jRep.get("reputation");
-            if(jid == null || !jid.isJsonPrimitive()) continue;
-            if(jid.getAsJsonPrimitive().isString())
-            {
+            if (jid == null || !jid.isJsonPrimitive()) continue;
+            if (jid.getAsJsonPrimitive().isString()) {
                 repId = jid.getAsString();
-            } else
-            {
+            } else {
                 repId = jid.getAsNumber().toString();
             }
-    
+
             HQMRep repObj = HQMQuestImporter.INSTANCE.reputations.get(repId);
-            if(repObj == null) continue;
-            
+            if (repObj == null) continue;
+
             int markA = repObj.getMarker(JsonHelper.GetNumber(jRep, "lower", -1).intValue());
             int markB = repObj.getMarker(JsonHelper.GetNumber(jRep, "upper", -1).intValue());
             boolean invert = JsonHelper.GetBoolean(jRep, "inverted", false);
-            
+
             TaskScoreboard task = new TaskScoreboard();
             task.scoreName = repObj.rName.replaceAll(" ", "_");
             task.scoreDisp = repObj.rName;
             task.type = "dummy";
-            
-            if(invert)
-            {
+
+            if (invert) {
                 task.operation = ScoreOperation.LESS_THAN;
                 task.target = markA;
-            } else
-            {
+            } else {
                 task.operation = ScoreOperation.MORE_OR_EQUAL;
                 task.target = markB;
             }
-            
+
             tasks.add(task);
         }
-        
+
         return tasks.toArray(new ITask[0]);
     }
 }

--- a/src/main/java/bq_standard/integration/nei/CustomPositionedStack.java
+++ b/src/main/java/bq_standard/integration/nei/CustomPositionedStack.java
@@ -1,7 +1,6 @@
 package bq_standard.integration.nei;
 
 import codechicken.nei.PositionedStack;
-
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/bq_standard/integration/nei/QuestRecipeHandler.java
+++ b/src/main/java/bq_standard/integration/nei/QuestRecipeHandler.java
@@ -1,5 +1,9 @@
 package bq_standard.integration.nei;
 
+import static codechicken.lib.gui.GuiDraw.changeTexture;
+import static codechicken.lib.gui.GuiDraw.drawTexturedModalRect;
+import static net.minecraft.util.EnumChatFormatting.*;
+
 import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuest;
@@ -30,12 +34,6 @@ import codechicken.nei.PositionedStack;
 import codechicken.nei.recipe.GuiRecipe;
 import codechicken.nei.recipe.TemplateRecipeHandler;
 import com.google.common.base.Stopwatch;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import org.lwjgl.opengl.GL11;
-
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,10 +41,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static codechicken.lib.gui.GuiDraw.changeTexture;
-import static codechicken.lib.gui.GuiDraw.drawTexturedModalRect;
-import static net.minecraft.util.EnumChatFormatting.*;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import org.lwjgl.opengl.GL11;
 
 @SuppressWarnings("UnstableApiUsage")
 public class QuestRecipeHandler extends TemplateRecipeHandler {
@@ -70,13 +69,15 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
         if (outputId.equals(getOverlayIdentifier())) {
             Stopwatch stopwatch = Stopwatch.createStarted();
             for (DBEntry<IQuest> quest : getVisibleQuests()) {
-                if (getTaskItemInputs(getTasks(quest.getValue())).isEmpty() && getRewardItemOutputs(getRewards(quest.getValue())).isEmpty()) {
+                if (getTaskItemInputs(getTasks(quest.getValue())).isEmpty()
+                        && getRewardItemOutputs(getRewards(quest.getValue())).isEmpty()) {
                     continue;
                 }
                 this.arecipes.add(new CachedQuestRecipe(quest.getValue(), quest.getID()));
             }
             if (debug) {
-                BQ_Standard.logger.debug(String.format("took %s: loadCraftingRecipes(String, Object...)", stopwatch.stop()));
+                BQ_Standard.logger.debug(
+                        String.format("took %s: loadCraftingRecipes(String, Object...)", stopwatch.stop()));
             }
         } else {
             super.loadCraftingRecipes(outputId, results);
@@ -281,7 +282,10 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
         String questTitle = UNDERLINE + recipe.questName;
         //noinspection unchecked
         List<String> titleArray = GuiDraw.fontRenderer.listFormattedStringToWidth(questTitle, GUI_WIDTH);
-        int titleWidth = titleArray.stream().map(GuiDraw::getStringWidth).max(Comparator.naturalOrder()).orElse(0);
+        int titleWidth = titleArray.stream()
+                .map(GuiDraw::getStringWidth)
+                .max(Comparator.naturalOrder())
+                .orElse(0);
         int titleHeight = GuiDraw.fontRenderer.FONT_HEIGHT + (titleArray.size() - 1) * LINE_SPACE;
 
         Point offset = gui.getRecipePosition(recipeIndex);
@@ -320,7 +324,13 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
                     int x = xOffset + (index % GRID_X_COUNT) * SLOT_SIZE;
                     int y = yOffset + (index / GRID_Y_COUNT) * SLOT_SIZE;
                     if (task instanceof TaskOptionalRetrieval) {
-                        inputs.add(new CustomPositionedStack(extractStacks(stack), x, y, DARK_GRAY.toString() + ITALIC + QuestTranslation.translate("bq_standard.task.optional_retrieval")));
+                        inputs.add(new CustomPositionedStack(
+                                extractStacks(stack),
+                                x,
+                                y,
+                                DARK_GRAY.toString()
+                                        + ITALIC
+                                        + QuestTranslation.translate("bq_standard.task.optional_retrieval")));
                     } else {
                         inputs.add(new PositionedStack(extractStacks(stack), x, y));
                     }
@@ -338,7 +348,13 @@ public class QuestRecipeHandler extends TemplateRecipeHandler {
                     int x = xOffset + (index % GRID_X_COUNT) * SLOT_SIZE;
                     int y = yOffset + (index / GRID_Y_COUNT) * SLOT_SIZE;
                     if (reward instanceof RewardChoice) {
-                        inputs.add(new CustomPositionedStack(extractStacks(stack), x, y, DARK_GRAY.toString() + ITALIC + QuestTranslation.translate("bq_standard.reward.choice")));
+                        inputs.add(new CustomPositionedStack(
+                                extractStacks(stack),
+                                x,
+                                y,
+                                DARK_GRAY.toString()
+                                        + ITALIC
+                                        + QuestTranslation.translate("bq_standard.reward.choice")));
                     } else {
                         inputs.add(new PositionedStack(extractStacks(stack), x, y));
                     }

--- a/src/main/java/bq_standard/items/ItemLootChest.java
+++ b/src/main/java/bq_standard/items/ItemLootChest.java
@@ -11,6 +11,8 @@ import bq_standard.rewards.loot.LootGroup;
 import bq_standard.rewards.loot.LootRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -23,195 +25,166 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ChestGenHooks;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class ItemLootChest extends Item
-{
-	public ItemLootChest()
-	{
-		this.setMaxStackSize(1);
-		this.setUnlocalizedName("bq_standard.loot_chest");
-		this.setTextureName("bq_standard:loot_chest");
-		this.setCreativeTab(QuestingAPI.getAPI(ApiReference.CREATIVE_TAB));
-	}
+public class ItemLootChest extends Item {
+    public ItemLootChest() {
+        this.setMaxStackSize(1);
+        this.setUnlocalizedName("bq_standard.loot_chest");
+        this.setTextureName("bq_standard:loot_chest");
+        this.setCreativeTab(QuestingAPI.getAPI(ApiReference.CREATIVE_TAB));
+    }
 
     /**
      * Called whenever this item is equipped and the right mouse button is pressed. Args: itemStack, world, entityPlayer
      */
-	@Override
-    public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player)
-    {
-		if(stack.getItemDamage() == 104)
-        {
-            if(world.isRemote || !(player instanceof EntityPlayerMP))
-            {
-                if(!player.capabilities.isCreativeMode) stack.stackSize--;
-    	        return stack;
+    @Override
+    public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+        if (stack.getItemDamage() == 104) {
+            if (world.isRemote || !(player instanceof EntityPlayerMP)) {
+                if (!player.capabilities.isCreativeMode) stack.stackSize--;
+                return stack;
             }
-            
+
             NBTTagCompound tag = stack.getTagCompound();
-            if(tag == null) tag = new NBTTagCompound();
-            
-	    	List<BigItemStack> lootItems = new ArrayList<>();
+            if (tag == null) tag = new NBTTagCompound();
+
+            List<BigItemStack> lootItems = new ArrayList<>();
             String lootName = tag.getString("fixedLootName");
             NBTTagList lootList = tag.getTagList("fixedLootList", 10);
-            
-            for(int i = 0; i < lootList.tagCount(); i++)
-            {
+
+            for (int i = 0; i < lootList.tagCount(); i++) {
                 lootItems.add(BigItemStack.loadItemStackFromNBT(lootList.getCompoundTagAt(i)));
             }
-	    	
-	    	boolean invoChanged = false;
-	    	for(BigItemStack s1 : lootItems)
-	    	{
-	    		for(ItemStack s2 : s1.getCombinedStacks())
-	    		{
-		    		if(!player.inventory.addItemStackToInventory(s2))
-		    		{
-		    			player.dropPlayerItemWithRandomChoice(s2, false);
-		    		} else if(!invoChanged)
-                    {
+
+            boolean invoChanged = false;
+            for (BigItemStack s1 : lootItems) {
+                for (ItemStack s2 : s1.getCombinedStacks()) {
+                    if (!player.inventory.addItemStackToInventory(s2)) {
+                        player.dropPlayerItemWithRandomChoice(s2, false);
+                    } else if (!invoChanged) {
                         invoChanged = true;
                     }
-	    		}
-	    	}
-	    	
-	    	if(invoChanged)
-            {
-	    		player.inventory.markDirty();
-	    		player.inventoryContainer.detectAndSendChanges();
+                }
             }
-	    	
-            NetLootClaim.sendReward((EntityPlayerMP)player, lootName, lootItems.toArray(new BigItemStack[0]));
-        } else if(stack.getItemDamage() == 103)
-        {
-            if(world.isRemote || !(player instanceof EntityPlayerMP))
-            {
-                if(!player.capabilities.isCreativeMode) stack.stackSize--;
-    	        return stack;
+
+            if (invoChanged) {
+                player.inventory.markDirty();
+                player.inventoryContainer.detectAndSendChanges();
             }
-            
-            String loottable = (stack.getTagCompound() != null && stack.getTagCompound().hasKey("loottable", 8)) ? stack.getTagCompound().getString("loottable") : "dungeonChest";
-            
-	    	List<BigItemStack> loot = new ArrayList<>();
-	    	for(int n = 1 + player.getRNG().nextInt(7); n > 0; n--)
-            {
+
+            NetLootClaim.sendReward((EntityPlayerMP) player, lootName, lootItems.toArray(new BigItemStack[0]));
+        } else if (stack.getItemDamage() == 103) {
+            if (world.isRemote || !(player instanceof EntityPlayerMP)) {
+                if (!player.capabilities.isCreativeMode) stack.stackSize--;
+                return stack;
+            }
+
+            String loottable =
+                    (stack.getTagCompound() != null && stack.getTagCompound().hasKey("loottable", 8))
+                            ? stack.getTagCompound().getString("loottable")
+                            : "dungeonChest";
+
+            List<BigItemStack> loot = new ArrayList<>();
+            for (int n = 1 + player.getRNG().nextInt(7); n > 0; n--) {
                 loot.add(new BigItemStack(ChestGenHooks.getOneItem(loottable, player.getRNG())));
             }
-	    	
-	    	boolean invoChanged = false;
-	    	for(BigItemStack s1 : loot)
-	    	{
-	    		for(ItemStack s2 : s1.getCombinedStacks())
-	    		{
-		    		if(!player.inventory.addItemStackToInventory(s2))
-		    		{
-		    			player.dropPlayerItemWithRandomChoice(s2, false);
-		    		} else if(!invoChanged)
-                    {
+
+            boolean invoChanged = false;
+            for (BigItemStack s1 : loot) {
+                for (ItemStack s2 : s1.getCombinedStacks()) {
+                    if (!player.inventory.addItemStackToInventory(s2)) {
+                        player.dropPlayerItemWithRandomChoice(s2, false);
+                    } else if (!invoChanged) {
                         invoChanged = true;
                     }
-	    		}
-	    	}
-	    	
-	    	if(invoChanged)
-            {
-	    		player.inventory.markDirty();
-	    		player.inventoryContainer.detectAndSendChanges();
+                }
             }
-	    	
-            NetLootClaim.sendReward((EntityPlayerMP)player, "Loot", loot.toArray(new BigItemStack[0]));
-        } else if(stack.getItemDamage() >= 102)
-    	{
-    		if(QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(player))
-    		{
-    			player.openGui(BQ_Standard.instance, 0, world, (int)player.posX, (int)player.posY, (int)player.posZ);
-    		}
-			return stack;
-    	} else if(!world.isRemote)
-    	{
-    	    float rarity = stack.getItemDamage() == 101 ? itemRand.nextFloat() : MathHelper.clamp_int(stack.getItemDamage(), 0, 100)/100F;
-    		LootGroup group = LootRegistry.INSTANCE.getWeightedGroup(rarity, itemRand);
-	    	List<BigItemStack> loot = new ArrayList<>();
-	    	String title = "No Loot Setup";
-	    	
-	    	if(group != null)
-	    	{
-	    		title = group.name;
-	    		List<BigItemStack> tmp = group.getRandomReward(itemRand);
-	    		if(tmp != null) loot.addAll(tmp);
-	    	}
-	    	
-	    	boolean invoChanged = false;
-	    	for(BigItemStack s1 : loot)
-	    	{
-	    		for(ItemStack s2 : s1.getCombinedStacks())
-	    		{
-		    		if(!player.inventory.addItemStackToInventory(s2))
-		    		{
-		    			player.dropPlayerItemWithRandomChoice(s2, false);
-		    		} else if(!invoChanged)
-                    {
+
+            if (invoChanged) {
+                player.inventory.markDirty();
+                player.inventoryContainer.detectAndSendChanges();
+            }
+
+            NetLootClaim.sendReward((EntityPlayerMP) player, "Loot", loot.toArray(new BigItemStack[0]));
+        } else if (stack.getItemDamage() >= 102) {
+            if (QuestingAPI.getAPI(ApiReference.SETTINGS).canUserEdit(player)) {
+                player.openGui(BQ_Standard.instance, 0, world, (int) player.posX, (int) player.posY, (int) player.posZ);
+            }
+            return stack;
+        } else if (!world.isRemote) {
+            float rarity = stack.getItemDamage() == 101
+                    ? itemRand.nextFloat()
+                    : MathHelper.clamp_int(stack.getItemDamage(), 0, 100) / 100F;
+            LootGroup group = LootRegistry.INSTANCE.getWeightedGroup(rarity, itemRand);
+            List<BigItemStack> loot = new ArrayList<>();
+            String title = "No Loot Setup";
+
+            if (group != null) {
+                title = group.name;
+                List<BigItemStack> tmp = group.getRandomReward(itemRand);
+                if (tmp != null) loot.addAll(tmp);
+            }
+
+            boolean invoChanged = false;
+            for (BigItemStack s1 : loot) {
+                for (ItemStack s2 : s1.getCombinedStacks()) {
+                    if (!player.inventory.addItemStackToInventory(s2)) {
+                        player.dropPlayerItemWithRandomChoice(s2, false);
+                    } else if (!invoChanged) {
                         invoChanged = true;
                     }
-	    		}
-	    	}
-	    	
-	    	if(invoChanged)
-            {
-	    		player.inventory.markDirty();
-	    		player.inventoryContainer.detectAndSendChanges();
+                }
             }
-	    	
-	    	if(player instanceof EntityPlayerMP)
-	    	{
-                NetLootClaim.sendReward((EntityPlayerMP)player, title, loot.toArray(new BigItemStack[0]));
-	    	}
-    	}
-    	
-    	if(!player.capabilities.isCreativeMode) stack.stackSize--;
-    	
-    	return stack;
+
+            if (invoChanged) {
+                player.inventory.markDirty();
+                player.inventoryContainer.detectAndSendChanges();
+            }
+
+            if (player instanceof EntityPlayerMP) {
+                NetLootClaim.sendReward((EntityPlayerMP) player, title, loot.toArray(new BigItemStack[0]));
+            }
+        }
+
+        if (!player.capabilities.isCreativeMode) stack.stackSize--;
+
+        return stack;
     }
-    
+
     private List<ItemStack> subItems = null;
 
     /**
      * returns a list of items with the same ID, but different meta (eg: dye returns 16 items)
      */
-	@Override
-	@SideOnly(Side.CLIENT)
+    @Override
+    @SideOnly(Side.CLIENT)
     @SuppressWarnings("unchecked")
-    public void getSubItems(Item item, CreativeTabs tab, List list)
-    {
-        if(tab != CreativeTabs.tabAllSearch && tab != this.getCreativeTab()) return;
-        if(subItems != null) // CACHED ITEMS
+    public void getSubItems(Item item, CreativeTabs tab, List list) {
+        if (tab != CreativeTabs.tabAllSearch && tab != this.getCreativeTab()) return;
+        if (subItems != null) // CACHED ITEMS
         {
             list.addAll(subItems);
             return;
         }
-        
+
         subItems = new ArrayList<>();
-        
+
         // NORMAL RARITY
         NBTTagCompound tag = new NBTTagCompound();
         tag.setBoolean("hideLootInfo", true);
-        for(int i = 0; i < 5; i++)
-        {
+        for (int i = 0; i < 5; i++) {
             ItemStack tmp = new ItemStack(this, 1, 25 * i);
-            tmp.setTagCompound((NBTTagCompound)tag.copy());
+            tmp.setTagCompound((NBTTagCompound) tag.copy());
             subItems.add(tmp);
         }
-        
+
         // TRUE RANDOM
         ItemStack tmp = new ItemStack(this, 1, 101);
-        tmp.setTagCompound((NBTTagCompound)tag.copy());
+        tmp.setTagCompound((NBTTagCompound) tag.copy());
         subItems.add(tmp);
-        
+
         // EDIT
         subItems.add(new ItemStack(this, 1, 102));
-        
+
         // VANILLA LOOT TABLE
         tag = new NBTTagCompound();
         tag.setBoolean("hideLootInfo", true);
@@ -219,7 +192,7 @@ public class ItemLootChest extends Item
         ItemStack lootStack = new ItemStack(this, 1, 103);
         lootStack.setTagCompound(tag);
         subItems.add(lootStack);
-        
+
         // FIXED ITEM SET
         tag = new NBTTagCompound();
         tag.setBoolean("hideLootInfo", true);
@@ -230,15 +203,14 @@ public class ItemLootChest extends Item
         tag.setString("fixedLootName", "Item Set");
         fixedLootStack.setTagCompound(tag);
         subItems.add(fixedLootStack);
-        
+
         list.addAll(subItems);
     }
-	
+
     @Override
     @SideOnly(Side.CLIENT)
-	@SuppressWarnings("deprecation")
-    public boolean hasEffect(ItemStack stack)
-    {
+    @SuppressWarnings("deprecation")
+    public boolean hasEffect(ItemStack stack) {
         return stack.getItemDamage() == 102;
     }
 
@@ -246,37 +218,33 @@ public class ItemLootChest extends Item
      * allows items to add custom lines of information to the mouseover description
      */
     @Override
-	@SideOnly(Side.CLIENT)
+    @SideOnly(Side.CLIENT)
     @SuppressWarnings("unchecked")
-    public void addInformation(ItemStack stack, EntityPlayer player, List tooltip, boolean advanced)
-    {
+    public void addInformation(ItemStack stack, EntityPlayer player, List tooltip, boolean advanced) {
         super.addInformation(stack, player, tooltip, advanced);
-        
+
         NBTTagCompound tag = stack.getTagCompound();
         boolean hideTooltip = tag == null || !tag.getBoolean("hideLootInfo");
-        if(hideTooltip && !QuestingAPI.getAPI(ApiReference.SETTINGS).getProperty(NativeProps.EDIT_MODE)) return;
-        
-        if(stack.getItemDamage() == 104)
-        {
-            if(tag == null) return;
+        if (hideTooltip && !QuestingAPI.getAPI(ApiReference.SETTINGS).getProperty(NativeProps.EDIT_MODE)) return;
+
+        if (stack.getItemDamage() == 104) {
+            if (tag == null) return;
             tooltip.add(QuestTranslation.translate("bq_standard.tooltip.fixed_loot", tag.getString("fixedLootName")));
-            tooltip.add(QuestTranslation.translate("bq_standard.tooltip.fixed_loot_size", tag.getTagList("fixedLootList", 10).tagCount()));
-        } else if(stack.getItemDamage() == 103)
-        {
-            if(tag == null) return;
+            tooltip.add(QuestTranslation.translate(
+                    "bq_standard.tooltip.fixed_loot_size",
+                    tag.getTagList("fixedLootList", 10).tagCount()));
+        } else if (stack.getItemDamage() == 103) {
+            if (tag == null) return;
             tooltip.add(QuestTranslation.translate("bq_standard.tooltip.loot_table", tag.getString("loottable")));
-        } else if(stack.getItemDamage() > 101)
-		{
-			tooltip.add(QuestTranslation.translate("betterquesting.btn.edit"));
-		} else
-		{
-			if(stack.getItemDamage() == 101)
-			{
-				tooltip.add(QuestTranslation.translate("bq_standard.tooltip.loot_chest", "???"));
-			} else
-			{
-				tooltip.add(QuestTranslation.translate("bq_standard.tooltip.loot_chest", MathHelper.clamp_int(stack.getItemDamage(), 0, 100) + "%"));
-			}
-		}
+        } else if (stack.getItemDamage() > 101) {
+            tooltip.add(QuestTranslation.translate("betterquesting.btn.edit"));
+        } else {
+            if (stack.getItemDamage() == 101) {
+                tooltip.add(QuestTranslation.translate("bq_standard.tooltip.loot_chest", "???"));
+            } else {
+                tooltip.add(QuestTranslation.translate(
+                        "bq_standard.tooltip.loot_chest", MathHelper.clamp_int(stack.getItemDamage(), 0, 100) + "%"));
+            }
+        }
     }
 }

--- a/src/main/java/bq_standard/network/handlers/NetLootClaim.java
+++ b/src/main/java/bq_standard/network/handlers/NetLootClaim.java
@@ -8,54 +8,46 @@ import bq_standard.client.gui.GuiLootChest;
 import bq_standard.core.BQ_Standard;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
+public class NetLootClaim {
+    private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:loot_claim");
 
-public class NetLootClaim
-{
-	private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:loot_claim");
-	
-	public static void registerHandler()
-    {
-        if(BQ_Standard.proxy.isClient())
-        {
+    public static void registerHandler() {
+        if (BQ_Standard.proxy.isClient()) {
             QuestingAPI.getAPI(ApiReference.PACKET_REG).registerClientHandler(ID_NAME, NetLootClaim::onClient);
         }
     }
-    
-    public static void sendReward(@Nonnull EntityPlayerMP player, @Nonnull String title, BigItemStack... items)
-    {
+
+    public static void sendReward(@Nonnull EntityPlayerMP player, @Nonnull String title, BigItemStack... items) {
         NBTTagCompound payload = new NBTTagCompound();
         NBTTagList list = new NBTTagList();
-        for(BigItemStack stack : items)
-        {
+        for (BigItemStack stack : items) {
             list.appendTag(stack.writeToNBT(new NBTTagCompound()));
         }
         payload.setTag("rewards", list);
         payload.setString("title", title);
         QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToPlayers(new QuestingPacket(ID_NAME, payload), player);
     }
-	
+
     @SideOnly(Side.CLIENT)
-	private static void onClient(NBTTagCompound data)
-	{
-		String title = data.getString("title");
-		List<BigItemStack> rewards = new ArrayList<>();
-		
-		NBTTagList list = data.getTagList("rewards", 10);
-		
-		for(int i = 0; i < list.tagCount(); i++)
-		{
-			rewards.add(BigItemStack.loadItemStackFromNBT(list.getCompoundTagAt(i)));
-		}
-		
-		Minecraft.getMinecraft().displayGuiScreen(new GuiLootChest(null, rewards, title));
-	}
+    private static void onClient(NBTTagCompound data) {
+        String title = data.getString("title");
+        List<BigItemStack> rewards = new ArrayList<>();
+
+        NBTTagList list = data.getTagList("rewards", 10);
+
+        for (int i = 0; i < list.tagCount(); i++) {
+            rewards.add(BigItemStack.loadItemStackFromNBT(list.getCompoundTagAt(i)));
+        }
+
+        Minecraft.getMinecraft().displayGuiScreen(new GuiLootChest(null, rewards, title));
+    }
 }

--- a/src/main/java/bq_standard/network/handlers/NetLootImport.java
+++ b/src/main/java/bq_standard/network/handlers/NetLootImport.java
@@ -15,40 +15,39 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.Level;
 
-public class NetLootImport
-{
-	private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:loot_import");
-	
-	public static void registerHandler()
-    {
+public class NetLootImport {
+    private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:loot_import");
+
+    public static void registerHandler() {
         QuestingAPI.getAPI(ApiReference.PACKET_REG).registerServerHandler(ID_NAME, NetLootImport::onServer);
     }
-    
+
     // TODO: Rework this for partial importing/editing
-    
+
     @SideOnly(Side.CLIENT)
-    public static void importLoot(NBTTagCompound data)
-    {
+    public static void importLoot(NBTTagCompound data) {
         NBTTagCompound payload = new NBTTagCompound();
         payload.setTag("data", data);
         QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(ID_NAME, payload));
     }
-    
-	private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message)
-	{
-	    EntityPlayerMP sender = message.getSecond();
-	    NBTTagCompound tag = message.getFirst();
-	    
-		if(sender.mcServer == null) return;
-		
-		if(!sender.mcServer.getConfigurationManager().func_152596_g(sender.getGameProfile()))
-		{
-			BQ_Standard.logger.log(Level.WARN, "Player " + sender.getCommandSenderName() + " (UUID:" + QuestingAPI.getQuestingUUID(sender) + ") tried to import loot without OP permissions!");
-			sender.addChatComponentMessage(new ChatComponentText(ChatFormatting.RED + "You need to be OP to edit loot!"));
-			return; // Player is not operator. Do nothing
-		}
-		
-		LootRegistry.INSTANCE.readFromNBT(tag.getCompoundTag("data"), false);
-		NetLootSync.sendSync(null);
-	}
+
+    private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
+        EntityPlayerMP sender = message.getSecond();
+        NBTTagCompound tag = message.getFirst();
+
+        if (sender.mcServer == null) return;
+
+        if (!sender.mcServer.getConfigurationManager().func_152596_g(sender.getGameProfile())) {
+            BQ_Standard.logger.log(
+                    Level.WARN,
+                    "Player " + sender.getCommandSenderName() + " (UUID:" + QuestingAPI.getQuestingUUID(sender)
+                            + ") tried to import loot without OP permissions!");
+            sender.addChatComponentMessage(
+                    new ChatComponentText(ChatFormatting.RED + "You need to be OP to edit loot!"));
+            return; // Player is not operator. Do nothing
+        }
+
+        LootRegistry.INSTANCE.readFromNBT(tag.getCompoundTag("data"), false);
+        NetLootSync.sendSync(null);
+    }
 }

--- a/src/main/java/bq_standard/network/handlers/NetLootSync.java
+++ b/src/main/java/bq_standard/network/handlers/NetLootSync.java
@@ -9,73 +9,66 @@ import bq_standard.rewards.loot.LootRegistry;
 import com.mojang.realmsclient.gui.ChatFormatting;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import javax.annotation.Nullable;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.Level;
 
-import javax.annotation.Nullable;
+public class NetLootSync {
+    private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:loot_database");
 
-public class NetLootSync
-{
-	private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:loot_database");
-	
-	public static void registerHandler()
-    {
+    public static void registerHandler() {
         QuestingAPI.getAPI(ApiReference.PACKET_REG).registerServerHandler(ID_NAME, NetLootSync::onServer);
-    
-        if(BQ_Standard.proxy.isClient())
-        {
+
+        if (BQ_Standard.proxy.isClient()) {
             QuestingAPI.getAPI(ApiReference.PACKET_REG).registerClientHandler(ID_NAME, NetLootSync::onClient);
         }
     }
-    
+
     @SideOnly(Side.CLIENT)
-    public static void requestEdit(NBTTagCompound data)
-    {
+    public static void requestEdit(NBTTagCompound data) {
         NBTTagCompound payload = new NBTTagCompound();
         payload.setTag("data", data);
         QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(ID_NAME, payload));
     }
-    
-    public static void sendSync(@Nullable EntityPlayerMP player)
-    {
+
+    public static void sendSync(@Nullable EntityPlayerMP player) {
         NBTTagCompound payload = new NBTTagCompound();
         payload.setTag("data", LootRegistry.INSTANCE.writeToNBT(new NBTTagCompound(), null));
-        
-        if(player == null)
-        {
+
+        if (player == null) {
             QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToAll(new QuestingPacket(ID_NAME, payload));
-        } else
-        {
+        } else {
             QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToPlayers(new QuestingPacket(ID_NAME, payload), player);
         }
     }
-    
-	private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message)
-	{
-	    EntityPlayerMP sender = message.getSecond();
-	    NBTTagCompound data = message.getFirst();
-	    
-	    if(sender.mcServer == null) return;
-		if(!sender.mcServer.getConfigurationManager().func_152596_g(sender.getGameProfile()))
-		{
-			BQ_Standard.logger.log(Level.WARN, "Player " + sender.getCommandSenderName() + " (UUID:" + QuestingAPI.getQuestingUUID(sender) + ") tried to edit loot chests without OP permissions!");
-			sender.addChatComponentMessage(new ChatComponentText(ChatFormatting.RED + "You need to be OP to edit loot!"));
-			return; // Player is not operator. Do nothing
-		}
-		
-		BQ_Standard.logger.log(Level.INFO, "Player " + sender.getCommandSenderName() + " edited loot chests");
-		
-		LootRegistry.INSTANCE.readFromNBT(data.getCompoundTag("data"), false);
-		sendSync(null);
-	}
-	
-	@SideOnly(Side.CLIENT)
-	private static void onClient(NBTTagCompound message)
-	{
-		LootRegistry.INSTANCE.readFromNBT(message.getCompoundTag("data"), false);
-		LootRegistry.INSTANCE.updateUI = true;
-	}
+
+    private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
+        EntityPlayerMP sender = message.getSecond();
+        NBTTagCompound data = message.getFirst();
+
+        if (sender.mcServer == null) return;
+        if (!sender.mcServer.getConfigurationManager().func_152596_g(sender.getGameProfile())) {
+            BQ_Standard.logger.log(
+                    Level.WARN,
+                    "Player " + sender.getCommandSenderName() + " (UUID:" + QuestingAPI.getQuestingUUID(sender)
+                            + ") tried to edit loot chests without OP permissions!");
+            sender.addChatComponentMessage(
+                    new ChatComponentText(ChatFormatting.RED + "You need to be OP to edit loot!"));
+            return; // Player is not operator. Do nothing
+        }
+
+        BQ_Standard.logger.log(Level.INFO, "Player " + sender.getCommandSenderName() + " edited loot chests");
+
+        LootRegistry.INSTANCE.readFromNBT(data.getCompoundTag("data"), false);
+        sendSync(null);
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static void onClient(NBTTagCompound message) {
+        LootRegistry.INSTANCE.readFromNBT(message.getCompoundTag("data"), false);
+        LootRegistry.INSTANCE.updateUI = true;
+    }
 }

--- a/src/main/java/bq_standard/network/handlers/NetRewardChoice.java
+++ b/src/main/java/bq_standard/network/handlers/NetRewardChoice.java
@@ -12,6 +12,7 @@ import bq_standard.core.BQ_Standard;
 import bq_standard.rewards.RewardChoice;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import javax.annotation.Nonnull;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -19,82 +20,71 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 
-import javax.annotation.Nonnull;
+public class NetRewardChoice {
+    private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:choice_reward");
 
-public class NetRewardChoice
-{
-	private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:choice_reward");
-	
-	public static void registerHandler()
-    {
+    public static void registerHandler() {
         QuestingAPI.getAPI(ApiReference.PACKET_REG).registerServerHandler(ID_NAME, NetRewardChoice::onServer);
-    
-        if(BQ_Standard.proxy.isClient())
-        {
+
+        if (BQ_Standard.proxy.isClient()) {
             QuestingAPI.getAPI(ApiReference.PACKET_REG).registerClientHandler(ID_NAME, NetRewardChoice::onClient);
         }
     }
-    
+
     @SideOnly(Side.CLIENT)
-    public static void requestChoice(int questID, int rewardID, int index)
-    {
+    public static void requestChoice(int questID, int rewardID, int index) {
         NBTTagCompound payload = new NBTTagCompound();
         payload.setInteger("questID", questID);
         payload.setInteger("rewardID", rewardID);
         payload.setInteger("selection", index);
         QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(ID_NAME, payload));
     }
-    
-    public static void sendChoice(@Nonnull EntityPlayerMP player, int questID, int rewardID, int index)
-    {
+
+    public static void sendChoice(@Nonnull EntityPlayerMP player, int questID, int rewardID, int index) {
         NBTTagCompound payload = new NBTTagCompound();
         payload.setInteger("questID", questID);
         payload.setInteger("rewardID", rewardID);
         payload.setInteger("selection", index);
         QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToPlayers(new QuestingPacket(ID_NAME, payload), player);
     }
-	
-	private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message)
-	{
-	    EntityPlayerMP sender = message.getSecond();
-	    NBTTagCompound tag = message.getFirst();
-	    
-		int qID = tag.hasKey("questID")? tag.getInteger("questID") : -1;
-		int rID = tag.hasKey("rewardID")? tag.getInteger("rewardID") : -1;
-		int sel = tag.hasKey("selection")? tag.getInteger("selection") : -1;
-		
-		if(qID < 0 || rID < 0) return;
-		
-		IQuest quest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(qID);
-		IReward reward = quest == null ? null : quest.getRewards().getValue(rID);
-		
-		if(reward instanceof RewardChoice)
-		{
-			RewardChoice rChoice = (RewardChoice)reward;
-			rChoice.setSelection(QuestingAPI.getQuestingUUID(sender), sel);
-			sendChoice(sender, qID, rID, sel);
-		}
-	}
-	
-	@SideOnly(Side.CLIENT)
-	private static void onClient(NBTTagCompound message)
-	{
-		EntityPlayerSP player = Minecraft.getMinecraft().thePlayer;
-		
-		int qID = message.hasKey("questID", 99)? message.getInteger("questID") : -1;
-		int rID = message.hasKey("rewardID", 99)? message.getInteger("rewardID") : -1;
-		int sel = message.hasKey("selection", 99)? message.getInteger("selection") : -1;
-		
-		if(qID < 0 || rID < 0) return;
-		
-		IQuest quest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(qID);
-		IReward reward = quest == null ? null : quest.getRewards().getValue(rID);
-		
-		if(reward instanceof RewardChoice)
-		{
-		    ((RewardChoice)reward).setSelection(QuestingAPI.getQuestingUUID(player), sel);
-		    MinecraftForge.EVENT_BUS.post(new DatabaseEvent.Update(DBType.QUEST));
-            //MinecraftForge.EVENT_BUS.post(new Update());
+
+    private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
+        EntityPlayerMP sender = message.getSecond();
+        NBTTagCompound tag = message.getFirst();
+
+        int qID = tag.hasKey("questID") ? tag.getInteger("questID") : -1;
+        int rID = tag.hasKey("rewardID") ? tag.getInteger("rewardID") : -1;
+        int sel = tag.hasKey("selection") ? tag.getInteger("selection") : -1;
+
+        if (qID < 0 || rID < 0) return;
+
+        IQuest quest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(qID);
+        IReward reward = quest == null ? null : quest.getRewards().getValue(rID);
+
+        if (reward instanceof RewardChoice) {
+            RewardChoice rChoice = (RewardChoice) reward;
+            rChoice.setSelection(QuestingAPI.getQuestingUUID(sender), sel);
+            sendChoice(sender, qID, rID, sel);
         }
-	}
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static void onClient(NBTTagCompound message) {
+        EntityPlayerSP player = Minecraft.getMinecraft().thePlayer;
+
+        int qID = message.hasKey("questID", 99) ? message.getInteger("questID") : -1;
+        int rID = message.hasKey("rewardID", 99) ? message.getInteger("rewardID") : -1;
+        int sel = message.hasKey("selection", 99) ? message.getInteger("selection") : -1;
+
+        if (qID < 0 || rID < 0) return;
+
+        IQuest quest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(qID);
+        IReward reward = quest == null ? null : quest.getRewards().getValue(rID);
+
+        if (reward instanceof RewardChoice) {
+            ((RewardChoice) reward).setSelection(QuestingAPI.getQuestingUUID(player), sel);
+            MinecraftForge.EVENT_BUS.post(new DatabaseEvent.Update(DBType.QUEST));
+            // MinecraftForge.EVENT_BUS.post(new Update());
+        }
+    }
 }

--- a/src/main/java/bq_standard/network/handlers/NetScoreSync.java
+++ b/src/main/java/bq_standard/network/handlers/NetScoreSync.java
@@ -5,43 +5,39 @@ import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.network.QuestingPacket;
 import bq_standard.ScoreboardBQ;
 import bq_standard.core.BQ_Standard;
+import java.util.Collections;
+import javax.annotation.Nullable;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nullable;
-import java.util.Collections;
+public class NetScoreSync {
+    private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:score_sync");
 
-public class NetScoreSync
-{
-	private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:score_sync");
-	
-	public static void registerHandler()
-    {
-        if(BQ_Standard.proxy.isClient())
-        {
+    public static void registerHandler() {
+        if (BQ_Standard.proxy.isClient()) {
             QuestingAPI.getAPI(ApiReference.PACKET_REG).registerClientHandler(ID_NAME, NetScoreSync::onClient);
         }
     }
-    
-    public static void sendScore(@Nullable EntityPlayerMP player)
-    {
+
+    public static void sendScore(@Nullable EntityPlayerMP player) {
         NBTTagCompound payload = new NBTTagCompound();
-        payload.setTag("data", ScoreboardBQ.INSTANCE.writeToNBT(new NBTTagList(), player == null ? null : Collections.singletonList(QuestingAPI.getQuestingUUID(player))));
+        payload.setTag(
+                "data",
+                ScoreboardBQ.INSTANCE.writeToNBT(
+                        new NBTTagList(),
+                        player == null ? null : Collections.singletonList(QuestingAPI.getQuestingUUID(player))));
         payload.setBoolean("merge", player != null);
-        
-        if(player == null)
-        {
+
+        if (player == null) {
             QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToAll(new QuestingPacket(ID_NAME, payload));
-        } else
-        {
+        } else {
             QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToPlayers(new QuestingPacket(ID_NAME, payload), player);
         }
     }
-	
-	private static void onClient(NBTTagCompound message)
-	{
-		ScoreboardBQ.INSTANCE.readFromNBT(message.getTagList("data", 10), message.getBoolean("merge"));
-	}
+
+    private static void onClient(NBTTagCompound message) {
+        ScoreboardBQ.INSTANCE.readFromNBT(message.getTagList("data", 10), message.getBoolean("merge"));
+    }
 }

--- a/src/main/java/bq_standard/network/handlers/NetTaskCheckbox.java
+++ b/src/main/java/bq_standard/network/handlers/NetTaskCheckbox.java
@@ -14,43 +14,37 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class NetTaskCheckbox
-{
-	private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:task_checkbox");
-	
-	public static void registerHandler()
-    {
+public class NetTaskCheckbox {
+    private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:task_checkbox");
+
+    public static void registerHandler() {
         QuestingAPI.getAPI(ApiReference.PACKET_REG).registerServerHandler(ID_NAME, NetTaskCheckbox::onServer);
     }
-    
+
     @SideOnly(Side.CLIENT)
-    public static void requestClick(int questID, int taskID)
-    {
+    public static void requestClick(int questID, int taskID) {
         NBTTagCompound payload = new NBTTagCompound();
         payload.setInteger("questID", questID);
         payload.setInteger("taskID", taskID);
         QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(ID_NAME, payload));
     }
-    
-	private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message)
-	{
-	    NBTTagCompound data = message.getFirst();
-	    EntityPlayerMP sender = message.getSecond();
-	    
-		int qId = !data.hasKey("questID", 99)? -1 : data.getInteger("questID");
-		int tId = !data.hasKey("taskID", 99)? -1 : data.getInteger("taskID");
-		
-		if(qId >= 0 && tId >= 0)
-		{
-            QuestCache qc = (QuestCache)sender.getExtendedProperties(QuestCache.LOC_QUEST_CACHE.toString());
+
+    private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
+        NBTTagCompound data = message.getFirst();
+        EntityPlayerMP sender = message.getSecond();
+
+        int qId = !data.hasKey("questID", 99) ? -1 : data.getInteger("questID");
+        int tId = !data.hasKey("taskID", 99) ? -1 : data.getInteger("taskID");
+
+        if (qId >= 0 && tId >= 0) {
+            QuestCache qc = (QuestCache) sender.getExtendedProperties(QuestCache.LOC_QUEST_CACHE.toString());
             IQuest quest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(qId);
             ITask task = quest == null ? null : quest.getTasks().getValue(tId);
-            
-            if(task instanceof TaskCheckbox)
-            {
+
+            if (task instanceof TaskCheckbox) {
                 task.setComplete(QuestingAPI.getQuestingUUID(sender));
-                if(qc != null) qc.markQuestDirty(qId);
+                if (qc != null) qc.markQuestDirty(qId);
             }
-		}
-	}
+        }
+    }
 }

--- a/src/main/java/bq_standard/network/handlers/NetTaskInteract.java
+++ b/src/main/java/bq_standard/network/handlers/NetTaskInteract.java
@@ -11,46 +11,51 @@ import betterquesting.api2.utils.Tuple2;
 import bq_standard.tasks.TaskInteractItem;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.List;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 
-import java.util.List;
+public class NetTaskInteract {
+    private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:task_interact");
 
-public class NetTaskInteract
-{
-	private static final ResourceLocation ID_NAME = new ResourceLocation("bq_standard:task_interact");
-	
-	public static void registerHandler()
-    {
+    public static void registerHandler() {
         QuestingAPI.getAPI(ApiReference.PACKET_REG).registerServerHandler(ID_NAME, NetTaskInteract::onServer);
     }
-    
+
     @SideOnly(Side.CLIENT)
-    public static void requestInteraction(boolean isHit)
-    {
+    public static void requestInteraction(boolean isHit) {
         NBTTagCompound payload = new NBTTagCompound();
         payload.setBoolean("isHit", isHit);
         QuestingAPI.getAPI(ApiReference.PACKET_SENDER).sendToServer(new QuestingPacket(ID_NAME, payload));
     }
-    
-	private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message)
-	{
-	    EntityPlayerMP sender = message.getSecond();
-	    NBTTagCompound tag = message.getFirst();
-        
+
+    private static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
+        EntityPlayerMP sender = message.getSecond();
+        NBTTagCompound tag = message.getFirst();
+
         ParticipantInfo pInfo = new ParticipantInfo(sender);
-		List<DBEntry<IQuest>> actQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
-        
+        List<DBEntry<IQuest>> actQuest =
+                QuestingAPI.getAPI(ApiReference.QUEST_DB).bulkLookup(pInfo.getSharedQuests());
+
         boolean isHit = tag.getBoolean("isHit");
-		
-		for(DBEntry<IQuest> entry : actQuest)
-		{
-		    for(DBEntry<ITask> task : entry.getValue().getTasks().getEntries())
-            {
-                if(task.getValue() instanceof TaskInteractItem) ((TaskInteractItem)task.getValue()).onInteract(pInfo, entry, null, null, -1, MathHelper.floor_double(sender.posX), MathHelper.floor_double(sender.posY), MathHelper.floor_double(sender.posZ), isHit);
+
+        for (DBEntry<IQuest> entry : actQuest) {
+            for (DBEntry<ITask> task : entry.getValue().getTasks().getEntries()) {
+                if (task.getValue() instanceof TaskInteractItem)
+                    ((TaskInteractItem) task.getValue())
+                            .onInteract(
+                                    pInfo,
+                                    entry,
+                                    null,
+                                    null,
+                                    -1,
+                                    MathHelper.floor_double(sender.posX),
+                                    MathHelper.floor_double(sender.posY),
+                                    MathHelper.floor_double(sender.posZ),
+                                    isHit);
             }
-		}
+        }
     }
 }

--- a/src/main/java/bq_standard/rewards/IRewardItemOutput.java
+++ b/src/main/java/bq_standard/rewards/IRewardItemOutput.java
@@ -2,7 +2,6 @@ package bq_standard.rewards;
 
 import betterquesting.api.questing.rewards.IReward;
 import betterquesting.api.utils.BigItemStack;
-
 import java.util.List;
 
 public interface IRewardItemOutput extends IReward {

--- a/src/main/java/bq_standard/rewards/RewardChoice.java
+++ b/src/main/java/bq_standard/rewards/RewardChoice.java
@@ -14,6 +14,7 @@ import bq_standard.core.BQ_Standard;
 import bq_standard.rewards.factory.FactoryRewardChoice;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.*;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -22,137 +23,120 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.Level;
 
-import java.util.*;
+public class RewardChoice implements IReward, IRewardItemOutput {
+    /**
+     * The selected reward index to be claimed.<br>
+     * Should only ever be used client side. NEVER onHit server
+     */
+    public final List<BigItemStack> choices = new ArrayList<>();
 
-public class RewardChoice implements IReward, IRewardItemOutput
-{
-	/**
-	 * The selected reward index to be claimed.<br>
-	 * Should only ever be used client side. NEVER onHit server
-	 */
-	public final List<BigItemStack> choices = new ArrayList<>();
-	private final TreeMap<UUID,Integer> selected = new TreeMap<>();
-	
-	@Override
-	public ResourceLocation getFactoryID()
-	{
-		return FactoryRewardChoice.INSTANCE.getRegistryName();
-	}
-	
-	@Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.reward.choice";
-	}
-	
-	public int getSelecton(UUID uuid)
-	{
-		if(!selected.containsKey(uuid))
-		{
-			return -1;
-		}
-		
-		return selected.get(uuid);
-	}
-	
-	public void setSelection(UUID uuid, int value)
-	{
-		selected.put(uuid, value);
-	}
-	
-	@Override
-	public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		if(!selected.containsKey(QuestingAPI.getQuestingUUID(player))) return false;
-		
-		int tmp = selected.get(QuestingAPI.getQuestingUUID(player));
-		return choices.size() <= 0 || (tmp >= 0 && tmp < choices.size());
-	}
+    private final TreeMap<UUID, Integer> selected = new TreeMap<>();
 
-	@Override
-	public void claimReward(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		UUID playerID = QuestingAPI.getQuestingUUID(player);
-		
-		if(choices.size() <= 0)
-		{
-			return;
-		} else if(!selected.containsKey(playerID))
-		{
-			return;
-		}
-		
-		int tmp = selected.get(playerID);
-		
-		if(tmp < 0 || tmp >= choices.size())
-		{
-			BQ_Standard.logger.log(Level.ERROR, "Choice reward was forcibly claimed with invalid choice", new IllegalStateException());
-			return;
-		}
-		
-		BigItemStack stack = choices.get(tmp);
-		stack = stack == null? null : stack.copy();
-		
-		if(stack == null || stack.stackSize <= 0)
-		{
-			BQ_Standard.logger.log(Level.WARN, "Claimed reward choice was null or was 0 in size!");
-			return;
-		}
-		
-		for(ItemStack s : stack.getCombinedStacks())
-		{
-			if(s.getTagCompound() != null)
-			{
-				s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getCommandSenderName()));
-				s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
-			}
-			
-			if(!player.inventory.addItemStackToInventory(s))
-			{
-				player.dropPlayerItemWithRandomChoice(s, false);
-			}
-		}
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound nbt)
-	{
-		choices.clear();
-		NBTTagList cList = nbt.getTagList("choices", 10);
-		for(int i = 0; i < cList.tagCount(); i++)
-		{
-			choices.add(JsonHelper.JsonToItemStack(cList.getCompoundTagAt(i)));
-		}
-	}
+    @Override
+    public ResourceLocation getFactoryID() {
+        return FactoryRewardChoice.INSTANCE.getRegistryName();
+    }
 
-	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound nbt)
-	{
-		NBTTagList rJson = new NBTTagList();
-		for(BigItemStack stack : choices)
-		{
-			rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
-		}
-		nbt.setTag("choices", rJson);
-		return nbt;
-	}
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.reward.choice";
+    }
 
-	@Override
-	@SideOnly(Side.CLIENT)
-	public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest)
-	{
-	    return new PanelRewardChoice(rect, quest, this);
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest)
-	{
-		return null;
-	}
+    public int getSelecton(UUID uuid) {
+        if (!selected.containsKey(uuid)) {
+            return -1;
+        }
 
-	@Override
-	public List<BigItemStack> getItemOutputs() {
-		return choices;
-	}
+        return selected.get(uuid);
+    }
+
+    public void setSelection(UUID uuid, int value) {
+        selected.put(uuid, value);
+    }
+
+    @Override
+    public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest) {
+        if (!selected.containsKey(QuestingAPI.getQuestingUUID(player))) return false;
+
+        int tmp = selected.get(QuestingAPI.getQuestingUUID(player));
+        return choices.size() <= 0 || (tmp >= 0 && tmp < choices.size());
+    }
+
+    @Override
+    public void claimReward(EntityPlayer player, DBEntry<IQuest> quest) {
+        UUID playerID = QuestingAPI.getQuestingUUID(player);
+
+        if (choices.size() <= 0) {
+            return;
+        } else if (!selected.containsKey(playerID)) {
+            return;
+        }
+
+        int tmp = selected.get(playerID);
+
+        if (tmp < 0 || tmp >= choices.size()) {
+            BQ_Standard.logger.log(
+                    Level.ERROR, "Choice reward was forcibly claimed with invalid choice", new IllegalStateException());
+            return;
+        }
+
+        BigItemStack stack = choices.get(tmp);
+        stack = stack == null ? null : stack.copy();
+
+        if (stack == null || stack.stackSize <= 0) {
+            BQ_Standard.logger.log(Level.WARN, "Claimed reward choice was null or was 0 in size!");
+            return;
+        }
+
+        for (ItemStack s : stack.getCombinedStacks()) {
+            if (s.getTagCompound() != null) {
+                s.setTagCompound(
+                        NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getCommandSenderName()));
+                s.setTagCompound(NBTReplaceUtil.replaceStrings(
+                        s.getTagCompound(),
+                        "VAR_UUID",
+                        QuestingAPI.getQuestingUUID(player).toString()));
+            }
+
+            if (!player.inventory.addItemStackToInventory(s)) {
+                player.dropPlayerItemWithRandomChoice(s, false);
+            }
+        }
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        choices.clear();
+        NBTTagList cList = nbt.getTagList("choices", 10);
+        for (int i = 0; i < cList.tagCount(); i++) {
+            choices.add(JsonHelper.JsonToItemStack(cList.getCompoundTagAt(i)));
+        }
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        NBTTagList rJson = new NBTTagList();
+        for (BigItemStack stack : choices) {
+            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+        }
+        nbt.setTag("choices", rJson);
+        return nbt;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest) {
+        return new PanelRewardChoice(rect, quest, this);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
+        return null;
+    }
+
+    @Override
+    public List<BigItemStack> getItemOutputs() {
+        return choices;
+    }
 }

--- a/src/main/java/bq_standard/rewards/RewardCommand.java
+++ b/src/main/java/bq_standard/rewards/RewardCommand.java
@@ -20,123 +20,104 @@ import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
-public class RewardCommand implements IReward
-{
-	public String command = "/say VAR_NAME Claimed a reward";
-	public boolean hideCmd = false;
-	public boolean viaPlayer = false;
-	
-	@Override
-	public ResourceLocation getFactoryID()
-	{
-		return FactoryRewardCommand.INSTANCE.getRegistryName();
-	}
-	
-	@Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.reward.command";
-	}
-	
-	@Override
-	public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		return true;
-	}
-	
-	@Override
-	public void claimReward(final EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		if(player.worldObj.isRemote) return;
-		
-		String tmp = command.replaceAll("VAR_NAME", player.getCommandSenderName());
-		final String finCom = tmp.replaceAll("VAR_UUID", QuestingAPI.getQuestingUUID(player).toString());
-		final MinecraftServer server = MinecraftServer.getServer();
-		
-		if(viaPlayer)
-		{
-			EventHandler.scheduleServerTask(() -> server.getCommandManager().executeCommand(new AdminExecute(player), finCom));
-		} else
-		{
-			final RewardCommandSender cmdSender = new RewardCommandSender(player.worldObj, (int)player.posX, (int)player.posY, (int)player.posZ);
-			
-			EventHandler.scheduleServerTask(() -> server.getCommandManager().executeCommand(cmdSender, finCom));
-		}
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound nbt)
-	{
-		command = nbt.getString("command");
-		hideCmd = nbt.getBoolean("hideCommand");
-		viaPlayer = nbt.getBoolean("viaPlayer");
-	}
-	
-	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound nbt)
-	{
-		nbt.setString("command", command);
-		nbt.setBoolean("hideCommand", hideCmd);
-		nbt.setBoolean("viaPlayer", viaPlayer);
-		return nbt;
-	}
-	
-	@Override
-	public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest)
-	{
-	    return new PanelRewardCommand(rect, this);
-	}
-	
-	@Override
-	public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest)
-	{
-		return null;
-	}
-	
-	public static class RewardCommandSender extends CommandBlockLogic
-	{
-		private final World world;
-		private final ChunkCoordinates blockLoc;
-		
-		private RewardCommandSender(World world, int x, int y, int z)
-	    {
-	    	blockLoc = new ChunkCoordinates(x, y, z);
-	    	this.world = world;
-	    }
-     
-		@Override
-		public ChunkCoordinates getPlayerCoordinates()
-		{
-			return blockLoc;
-		}
-  
-		@Override
-		public World getEntityWorld()
-		{
-			return world;
-		}
-  
-		@Override
-		public void func_145756_e()
-        {
-        
+public class RewardCommand implements IReward {
+    public String command = "/say VAR_NAME Claimed a reward";
+    public boolean hideCmd = false;
+    public boolean viaPlayer = false;
+
+    @Override
+    public ResourceLocation getFactoryID() {
+        return FactoryRewardCommand.INSTANCE.getRegistryName();
+    }
+
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.reward.command";
+    }
+
+    @Override
+    public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest) {
+        return true;
+    }
+
+    @Override
+    public void claimReward(final EntityPlayer player, DBEntry<IQuest> quest) {
+        if (player.worldObj.isRemote) return;
+
+        String tmp = command.replaceAll("VAR_NAME", player.getCommandSenderName());
+        final String finCom =
+                tmp.replaceAll("VAR_UUID", QuestingAPI.getQuestingUUID(player).toString());
+        final MinecraftServer server = MinecraftServer.getServer();
+
+        if (viaPlayer) {
+            EventHandler.scheduleServerTask(
+                    () -> server.getCommandManager().executeCommand(new AdminExecute(player), finCom));
+        } else {
+            final RewardCommandSender cmdSender =
+                    new RewardCommandSender(player.worldObj, (int) player.posX, (int) player.posY, (int) player.posZ);
+
+            EventHandler.scheduleServerTask(() -> server.getCommandManager().executeCommand(cmdSender, finCom));
         }
-        
-		@Override
-		public int func_145751_f()
-		{
-			return 0;
-		}
-  
-		@Override
-		public void func_145757_a(ByteBuf p_145757_1_)
-		{
-		}
-  
-		@Override
-	    public String getCommandSenderName()
-	    {
-	        return "BetterQuesting";
-	    }
-	}
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        command = nbt.getString("command");
+        hideCmd = nbt.getBoolean("hideCommand");
+        viaPlayer = nbt.getBoolean("viaPlayer");
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        nbt.setString("command", command);
+        nbt.setBoolean("hideCommand", hideCmd);
+        nbt.setBoolean("viaPlayer", viaPlayer);
+        return nbt;
+    }
+
+    @Override
+    public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest) {
+        return new PanelRewardCommand(rect, this);
+    }
+
+    @Override
+    public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
+        return null;
+    }
+
+    public static class RewardCommandSender extends CommandBlockLogic {
+        private final World world;
+        private final ChunkCoordinates blockLoc;
+
+        private RewardCommandSender(World world, int x, int y, int z) {
+            blockLoc = new ChunkCoordinates(x, y, z);
+            this.world = world;
+        }
+
+        @Override
+        public ChunkCoordinates getPlayerCoordinates() {
+            return blockLoc;
+        }
+
+        @Override
+        public World getEntityWorld() {
+            return world;
+        }
+
+        @Override
+        public void func_145756_e() {}
+
+        @Override
+        public int func_145751_f() {
+            return 0;
+        }
+
+        @Override
+        public void func_145757_a(ByteBuf p_145757_1_) {}
+
+        @Override
+        public String getCommandSenderName() {
+            return "BetterQuesting";
+        }
+    }
 }

--- a/src/main/java/bq_standard/rewards/RewardItem.java
+++ b/src/main/java/bq_standard/rewards/RewardItem.java
@@ -12,6 +12,8 @@ import bq_standard.NBTReplaceUtil;
 import bq_standard.client.gui.rewards.PanelRewardItem;
 import bq_standard.core.BQ_Standard;
 import bq_standard.rewards.factory.FactoryRewardItem;
+import java.util.ArrayList;
+import java.util.List;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -20,98 +22,82 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.Level;
 
-import java.util.ArrayList;
-import java.util.List;
+public class RewardItem implements IReward, IRewardItemOutput {
+    public final List<BigItemStack> items = new ArrayList<>();
 
-public class RewardItem implements IReward, IRewardItemOutput
-{
-	public final List<BigItemStack> items = new ArrayList<>();
-	
-	@Override
-	public ResourceLocation getFactoryID()
-	{
-		return FactoryRewardItem.INSTANCE.getRegistryName();
-	}
-	
-	@Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.reward.item";
-	}
-	
-	@Override
-	public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		return true;
-	}
+    @Override
+    public ResourceLocation getFactoryID() {
+        return FactoryRewardItem.INSTANCE.getRegistryName();
+    }
 
-	@Override
-	public void claimReward(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		for(BigItemStack r : items)
-		{
-			BigItemStack stack = r.copy();
-			
-			for(ItemStack s : stack.getCombinedStacks())
-			{
-				if(s.getTagCompound() != null)
-				{
-					s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_NAME", player.getCommandSenderName()));
-					s.setTagCompound(NBTReplaceUtil.replaceStrings(s.getTagCompound(), "VAR_UUID", QuestingAPI.getQuestingUUID(player).toString()));
-				}
-				
-				if(!player.inventory.addItemStackToInventory(s))
-				{
-					player.dropPlayerItemWithRandomChoice(s, false);
-				}
-			}
-		}
-	}
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.reward.item";
+    }
 
-	@Override
-	public void readFromNBT(NBTTagCompound nbt)
-	{
-		items.clear();
-		NBTTagList rList = nbt.getTagList("rewards", 10);
-		for(int i = 0; i < rList.tagCount(); i++)
-		{
-			try
-			{
-				BigItemStack item = JsonHelper.JsonToItemStack(rList.getCompoundTagAt(i));
-				if(item != null) items.add(item);
-			} catch(Exception e)
-			{
-				BQ_Standard.logger.log(Level.ERROR, "Unable to load reward item data", e);
-			}
-		}
-	}
+    @Override
+    public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest) {
+        return true;
+    }
 
-	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound nbt)
-	{
-		NBTTagList rJson = new NBTTagList();
-		for(BigItemStack stack : items)
-		{
-			rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
-		}
-		nbt.setTag("rewards", rJson);
-		return nbt;
-	}
+    @Override
+    public void claimReward(EntityPlayer player, DBEntry<IQuest> quest) {
+        for (BigItemStack r : items) {
+            BigItemStack stack = r.copy();
 
-	@Override
-	public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest)
-	{
-	    return new PanelRewardItem(rect, this);
-	}
-	
-	@Override
-	public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest)
-	{
-		return null;
-	}
+            for (ItemStack s : stack.getCombinedStacks()) {
+                if (s.getTagCompound() != null) {
+                    s.setTagCompound(NBTReplaceUtil.replaceStrings(
+                            s.getTagCompound(), "VAR_NAME", player.getCommandSenderName()));
+                    s.setTagCompound(NBTReplaceUtil.replaceStrings(
+                            s.getTagCompound(),
+                            "VAR_UUID",
+                            QuestingAPI.getQuestingUUID(player).toString()));
+                }
 
-	@Override
-	public List<BigItemStack> getItemOutputs() {
-		return items;
-	}
+                if (!player.inventory.addItemStackToInventory(s)) {
+                    player.dropPlayerItemWithRandomChoice(s, false);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        items.clear();
+        NBTTagList rList = nbt.getTagList("rewards", 10);
+        for (int i = 0; i < rList.tagCount(); i++) {
+            try {
+                BigItemStack item = JsonHelper.JsonToItemStack(rList.getCompoundTagAt(i));
+                if (item != null) items.add(item);
+            } catch (Exception e) {
+                BQ_Standard.logger.log(Level.ERROR, "Unable to load reward item data", e);
+            }
+        }
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        NBTTagList rJson = new NBTTagList();
+        for (BigItemStack stack : items) {
+            rJson.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+        }
+        nbt.setTag("rewards", rJson);
+        return nbt;
+    }
+
+    @Override
+    public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest) {
+        return new PanelRewardItem(rect, this);
+    }
+
+    @Override
+    public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
+        return null;
+    }
+
+    @Override
+    public List<BigItemStack> getItemOutputs() {
+        return items;
+    }
 }

--- a/src/main/java/bq_standard/rewards/RewardQuestCompletion.java
+++ b/src/main/java/bq_standard/rewards/RewardQuestCompletion.java
@@ -9,63 +9,57 @@ import betterquesting.api2.client.gui.panels.IGuiPanel;
 import betterquesting.api2.storage.DBEntry;
 import bq_standard.client.gui.rewards.PanelRewardQuestCompletion;
 import bq_standard.rewards.factory.FactoryRewardQuestCompletion;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+import java.util.UUID;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-import java.util.UUID;
-
 public class RewardQuestCompletion implements IReward {
-	public int questNum = -1;
-	
-	@Override
-	public ResourceLocation getFactoryID() {
-		return FactoryRewardQuestCompletion.INSTANCE.getRegistryName();
-	}
-	
-	@Override
-	public String getUnlocalisedName() {
-		return "bq_standard.reward.questcompletion";
-	}
-	
-	@Override
-	public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest)	{
-		return true;
-	}
+    public int questNum = -1;
 
-	@Override
-	public void claimReward(EntityPlayer player, DBEntry<IQuest> quest)	{
-		if (questNum == -1)
-			return;
-		IQuest targetQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(questNum);
-		if (targetQuest == null)
-			return;
-		UUID uuid = QuestingAPI.getQuestingUUID(player);
-		if (!targetQuest.isComplete(uuid))
-			targetQuest.setComplete(uuid, System.currentTimeMillis());
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound nbt) {
-		questNum = nbt.getInteger("quest");
-	}
-	
-	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-		nbt.setInteger("quest", questNum);
-		return nbt;
-	}
+    @Override
+    public ResourceLocation getFactoryID() {
+        return FactoryRewardQuestCompletion.INSTANCE.getRegistryName();
+    }
 
-	@Override
-	public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest) {
-	    return new PanelRewardQuestCompletion(rect, this);
-	}
-	
-	@Override
-	public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
-		return null;
-	}
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.reward.questcompletion";
+    }
+
+    @Override
+    public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest) {
+        return true;
+    }
+
+    @Override
+    public void claimReward(EntityPlayer player, DBEntry<IQuest> quest) {
+        if (questNum == -1) return;
+        IQuest targetQuest = QuestingAPI.getAPI(ApiReference.QUEST_DB).getValue(questNum);
+        if (targetQuest == null) return;
+        UUID uuid = QuestingAPI.getQuestingUUID(player);
+        if (!targetQuest.isComplete(uuid)) targetQuest.setComplete(uuid, System.currentTimeMillis());
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        questNum = nbt.getInteger("quest");
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        nbt.setInteger("quest", questNum);
+        return nbt;
+    }
+
+    @Override
+    public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest) {
+        return new PanelRewardQuestCompletion(rect, this);
+    }
+
+    @Override
+    public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
+        return null;
+    }
 }

--- a/src/main/java/bq_standard/rewards/RewardScoreboard.java
+++ b/src/main/java/bq_standard/rewards/RewardScoreboard.java
@@ -17,99 +17,85 @@ import net.minecraft.scoreboard.*;
 import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.Level;
 
-public class RewardScoreboard implements IReward
-{
-	public String score = "Reputation";
-	public String type = "dummy";
-	public boolean relative = true;
-	public int value = 1;
-	
-	@Override
-	public ResourceLocation getFactoryID()
-	{
-		return FactoryRewardScoreboard.INSTANCE.getRegistryName();
-	}
-	
-	@Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.reward.scoreboard";
-	}
-	
-	@Override
-	public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		return true;
-	}
-	
-	@Override
-	public void claimReward(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		Scoreboard board = player.getWorldScoreboard();
-		if(board == null) return;
-		
-		ScoreObjective scoreObj = board.getObjective(score);
-		
-		if(scoreObj == null)
-		{
-			try
-			{
-		        IScoreObjectiveCriteria criteria = (IScoreObjectiveCriteria)IScoreObjectiveCriteria.field_96643_a.get(type);
-		        criteria = criteria != null? criteria : new ScoreDummyCriteria(score);
-				scoreObj = board.addScoreObjective(score, criteria);
-				scoreObj.setDisplayName(score);
-			} catch(Exception e)
-			{
-				BQ_Standard.logger.log(Level.ERROR, "Unable to create score '" + score + "' for reward!", e);
-			}
-		}
-		
-		if(scoreObj == null || scoreObj.getCriteria().isReadOnly())
-		{
-			return;
-		}
-		
-		Score s = board.func_96529_a(player.getCommandSenderName(), scoreObj);
-		
-		if(relative)
-		{
-			s.increseScore(value);
-		} else
-		{
-			s.setScorePoints(value);
-		}
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound json)
-	{
-		score = json.getString("score");
-		type = json.getString("type");
-		value = json.getInteger("value");
-		relative = json.getBoolean("relative");
-	}
-	
-	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound json)
-	{
-		json.setString("score", score);
-		json.setString("type", "dummy");
-		json.setInteger("value", value);
-		json.setBoolean("relative", relative);
-		return json;
-	}
+public class RewardScoreboard implements IReward {
+    public String score = "Reputation";
+    public String type = "dummy";
+    public boolean relative = true;
+    public int value = 1;
 
-	@Override
-	@SideOnly(Side.CLIENT)
-	public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest)
-	{
-	    return new PanelRewardScoreboard(rect, this);
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest)
-	{
-		return null;
-	}
+    @Override
+    public ResourceLocation getFactoryID() {
+        return FactoryRewardScoreboard.INSTANCE.getRegistryName();
+    }
+
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.reward.scoreboard";
+    }
+
+    @Override
+    public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest) {
+        return true;
+    }
+
+    @Override
+    public void claimReward(EntityPlayer player, DBEntry<IQuest> quest) {
+        Scoreboard board = player.getWorldScoreboard();
+        if (board == null) return;
+
+        ScoreObjective scoreObj = board.getObjective(score);
+
+        if (scoreObj == null) {
+            try {
+                IScoreObjectiveCriteria criteria =
+                        (IScoreObjectiveCriteria) IScoreObjectiveCriteria.field_96643_a.get(type);
+                criteria = criteria != null ? criteria : new ScoreDummyCriteria(score);
+                scoreObj = board.addScoreObjective(score, criteria);
+                scoreObj.setDisplayName(score);
+            } catch (Exception e) {
+                BQ_Standard.logger.log(Level.ERROR, "Unable to create score '" + score + "' for reward!", e);
+            }
+        }
+
+        if (scoreObj == null || scoreObj.getCriteria().isReadOnly()) {
+            return;
+        }
+
+        Score s = board.func_96529_a(player.getCommandSenderName(), scoreObj);
+
+        if (relative) {
+            s.increseScore(value);
+        } else {
+            s.setScorePoints(value);
+        }
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound json) {
+        score = json.getString("score");
+        type = json.getString("type");
+        value = json.getInteger("value");
+        relative = json.getBoolean("relative");
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound json) {
+        json.setString("score", score);
+        json.setString("type", "dummy");
+        json.setInteger("value", value);
+        json.setBoolean("relative", relative);
+        return json;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest) {
+        return new PanelRewardScoreboard(rect, this);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
+        return null;
+    }
 }

--- a/src/main/java/bq_standard/rewards/RewardXP.java
+++ b/src/main/java/bq_standard/rewards/RewardXP.java
@@ -15,61 +15,52 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class RewardXP implements IReward
-{
-	public int amount = 1;
-	public boolean levels = true;
-	
-	@Override
-	public ResourceLocation getFactoryID()
-	{
-		return FactoryRewardXP.INSTANCE.getRegistryName();
-	}
-	
-	@Override
-	public String getUnlocalisedName()
-	{
-		return "bq_standard.reward.xp";
-	}
-	
-	@Override
-	public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		return true;
-	}
-	
-	@Override
-	public void claimReward(EntityPlayer player, DBEntry<IQuest> quest)
-	{
-		XPHelper.addXP(player, !levels? amount : XPHelper.getLevelXP(amount));
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound nbt)
-	{
-		amount = nbt.getInteger("amount");
-		levels = nbt.getBoolean("isLevels");
-	}
-	
-	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound nbt)
-	{
-		nbt.setInteger("amount", amount);
-		nbt.setBoolean("isLevels", levels);
-		return nbt;
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest)
-	{
-	    return new PanelRewardXP(rect, this);
-	}
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest)
-	{
-		return null;
-	}
+public class RewardXP implements IReward {
+    public int amount = 1;
+    public boolean levels = true;
+
+    @Override
+    public ResourceLocation getFactoryID() {
+        return FactoryRewardXP.INSTANCE.getRegistryName();
+    }
+
+    @Override
+    public String getUnlocalisedName() {
+        return "bq_standard.reward.xp";
+    }
+
+    @Override
+    public boolean canClaim(EntityPlayer player, DBEntry<IQuest> quest) {
+        return true;
+    }
+
+    @Override
+    public void claimReward(EntityPlayer player, DBEntry<IQuest> quest) {
+        XPHelper.addXP(player, !levels ? amount : XPHelper.getLevelXP(amount));
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        amount = nbt.getInteger("amount");
+        levels = nbt.getBoolean("isLevels");
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        nbt.setInteger("amount", amount);
+        nbt.setBoolean("isLevels", levels);
+        return nbt;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IGuiPanel getRewardGui(IGuiRect rect, DBEntry<IQuest> quest) {
+        return new PanelRewardXP(rect, this);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen getRewardEditor(GuiScreen screen, DBEntry<IQuest> quest) {
+        return null;
+    }
 }

--- a/src/main/java/bq_standard/rewards/factory/FactoryRewardChoice.java
+++ b/src/main/java/bq_standard/rewards/factory/FactoryRewardChoice.java
@@ -7,28 +7,23 @@ import bq_standard.rewards.RewardChoice;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryRewardChoice implements IFactoryData<IReward, NBTTagCompound>
-{
-	public static final FactoryRewardChoice INSTANCE = new FactoryRewardChoice();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID, "choice");
-	}
+public class FactoryRewardChoice implements IFactoryData<IReward, NBTTagCompound> {
+    public static final FactoryRewardChoice INSTANCE = new FactoryRewardChoice();
 
-	@Override
-	public RewardChoice createNew()
-	{
-		return new RewardChoice();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID, "choice");
+    }
 
-	@Override
-	public RewardChoice loadFromData(NBTTagCompound json)
-	{
-		RewardChoice reward = new RewardChoice();
-		reward.readFromNBT(json);
-		return reward;
-	}
-	
+    @Override
+    public RewardChoice createNew() {
+        return new RewardChoice();
+    }
+
+    @Override
+    public RewardChoice loadFromData(NBTTagCompound json) {
+        RewardChoice reward = new RewardChoice();
+        reward.readFromNBT(json);
+        return reward;
+    }
 }

--- a/src/main/java/bq_standard/rewards/factory/FactoryRewardCommand.java
+++ b/src/main/java/bq_standard/rewards/factory/FactoryRewardCommand.java
@@ -7,28 +7,23 @@ import bq_standard.rewards.RewardCommand;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryRewardCommand implements IFactoryData<IReward, NBTTagCompound>
-{
-	public static final FactoryRewardCommand INSTANCE = new FactoryRewardCommand();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID, "command");
-	}
+public class FactoryRewardCommand implements IFactoryData<IReward, NBTTagCompound> {
+    public static final FactoryRewardCommand INSTANCE = new FactoryRewardCommand();
 
-	@Override
-	public RewardCommand createNew()
-	{
-		return new RewardCommand();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID, "command");
+    }
 
-	@Override
-	public RewardCommand loadFromData(NBTTagCompound json)
-	{
-		RewardCommand reward = new RewardCommand();
-		reward.readFromNBT(json);
-		return reward;
-	}
-	
+    @Override
+    public RewardCommand createNew() {
+        return new RewardCommand();
+    }
+
+    @Override
+    public RewardCommand loadFromData(NBTTagCompound json) {
+        RewardCommand reward = new RewardCommand();
+        reward.readFromNBT(json);
+        return reward;
+    }
 }

--- a/src/main/java/bq_standard/rewards/factory/FactoryRewardItem.java
+++ b/src/main/java/bq_standard/rewards/factory/FactoryRewardItem.java
@@ -7,28 +7,23 @@ import bq_standard.rewards.RewardItem;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryRewardItem implements IFactoryData<IReward, NBTTagCompound>
-{
-	public static final FactoryRewardItem INSTANCE = new FactoryRewardItem();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID, "item");
-	}
+public class FactoryRewardItem implements IFactoryData<IReward, NBTTagCompound> {
+    public static final FactoryRewardItem INSTANCE = new FactoryRewardItem();
 
-	@Override
-	public RewardItem createNew()
-	{
-		return new RewardItem();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID, "item");
+    }
 
-	@Override
-	public RewardItem loadFromData(NBTTagCompound json)
-	{
-		RewardItem reward = new RewardItem();
-		reward.readFromNBT(json);
-		return reward;
-	}
-	
+    @Override
+    public RewardItem createNew() {
+        return new RewardItem();
+    }
+
+    @Override
+    public RewardItem loadFromData(NBTTagCompound json) {
+        RewardItem reward = new RewardItem();
+        reward.readFromNBT(json);
+        return reward;
+    }
 }

--- a/src/main/java/bq_standard/rewards/factory/FactoryRewardQuestCompletion.java
+++ b/src/main/java/bq_standard/rewards/factory/FactoryRewardQuestCompletion.java
@@ -7,23 +7,23 @@ import bq_standard.rewards.RewardQuestCompletion;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryRewardQuestCompletion  implements IFactoryData<IReward, NBTTagCompound> {
-public static final FactoryRewardQuestCompletion INSTANCE = new FactoryRewardQuestCompletion();
-	
-	@Override
-	public ResourceLocation getRegistryName() {
-		return new ResourceLocation(BQ_Standard.MODID, "questcompletion");
-	}
+public class FactoryRewardQuestCompletion implements IFactoryData<IReward, NBTTagCompound> {
+    public static final FactoryRewardQuestCompletion INSTANCE = new FactoryRewardQuestCompletion();
 
-	@Override
-	public RewardQuestCompletion createNew() {
-		return new RewardQuestCompletion();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID, "questcompletion");
+    }
 
-	@Override
-	public RewardQuestCompletion loadFromData(NBTTagCompound json) {
-		RewardQuestCompletion reward = new RewardQuestCompletion();
-		reward.readFromNBT(json);
-		return reward;
-	}
+    @Override
+    public RewardQuestCompletion createNew() {
+        return new RewardQuestCompletion();
+    }
+
+    @Override
+    public RewardQuestCompletion loadFromData(NBTTagCompound json) {
+        RewardQuestCompletion reward = new RewardQuestCompletion();
+        reward.readFromNBT(json);
+        return reward;
+    }
 }

--- a/src/main/java/bq_standard/rewards/factory/FactoryRewardScoreboard.java
+++ b/src/main/java/bq_standard/rewards/factory/FactoryRewardScoreboard.java
@@ -7,28 +7,23 @@ import bq_standard.rewards.RewardScoreboard;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryRewardScoreboard implements IFactoryData<IReward, NBTTagCompound>
-{
-	public static final FactoryRewardScoreboard INSTANCE = new FactoryRewardScoreboard();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID, "scoreboard");
-	}
+public class FactoryRewardScoreboard implements IFactoryData<IReward, NBTTagCompound> {
+    public static final FactoryRewardScoreboard INSTANCE = new FactoryRewardScoreboard();
 
-	@Override
-	public RewardScoreboard createNew()
-	{
-		return new RewardScoreboard();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID, "scoreboard");
+    }
 
-	@Override
-	public RewardScoreboard loadFromData(NBTTagCompound json)
-	{
-		RewardScoreboard reward = new RewardScoreboard();
-		reward.readFromNBT(json);
-		return reward;
-	}
-	
+    @Override
+    public RewardScoreboard createNew() {
+        return new RewardScoreboard();
+    }
+
+    @Override
+    public RewardScoreboard loadFromData(NBTTagCompound json) {
+        RewardScoreboard reward = new RewardScoreboard();
+        reward.readFromNBT(json);
+        return reward;
+    }
 }

--- a/src/main/java/bq_standard/rewards/factory/FactoryRewardXP.java
+++ b/src/main/java/bq_standard/rewards/factory/FactoryRewardXP.java
@@ -7,28 +7,23 @@ import bq_standard.rewards.RewardXP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryRewardXP implements IFactoryData<IReward, NBTTagCompound>
-{
-	public static final FactoryRewardXP INSTANCE = new FactoryRewardXP();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID, "xp");
-	}
+public class FactoryRewardXP implements IFactoryData<IReward, NBTTagCompound> {
+    public static final FactoryRewardXP INSTANCE = new FactoryRewardXP();
 
-	@Override
-	public RewardXP createNew()
-	{
-		return new RewardXP();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID, "xp");
+    }
 
-	@Override
-	public RewardXP loadFromData(NBTTagCompound json)
-	{
-		RewardXP reward = new RewardXP();
-		reward.readFromNBT(json);
-		return reward;
-	}
-	
+    @Override
+    public RewardXP createNew() {
+        return new RewardXP();
+    }
+
+    @Override
+    public RewardXP loadFromData(NBTTagCompound json) {
+        RewardXP reward = new RewardXP();
+        reward.readFromNBT(json);
+        return reward;
+    }
 }

--- a/src/main/java/bq_standard/rewards/loot/LootGroup.java
+++ b/src/main/java/bq_standard/rewards/loot/LootGroup.java
@@ -6,136 +6,117 @@ import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.storage.INBTSaveLoad;
 import betterquesting.api2.storage.SimpleDatabase;
 import bq_standard.rewards.loot.LootGroup.LootEntry;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 
-public class LootGroup extends SimpleDatabase<LootEntry> implements INBTSaveLoad<NBTTagCompound>
-{
-	public String name = "Loot Group";
-	public int weight = 1;
-	
-	public List<BigItemStack> getRandomReward(Random rand)
-	{
-		int total = getTotalWeight();
-		float r = rand.nextFloat() * total;
-		int cnt = 0;
-		
-		for(DBEntry<LootEntry> entry : getEntries())
-		{
-			cnt += entry.getValue().weight;
-			if(cnt >= r)
-			{
-				return entry.getValue().items;
-			}
-		}
-		
-		return Collections.emptyList();
-	}
-	
-	public int getTotalWeight()
-	{
-		int i = 0;
-		
-		for(DBEntry<LootEntry> entry : getEntries())
-		{
-			i += entry.getValue().weight;
-		}
-		
-		return i;
-	}
-	
-	@Override
-	public void readFromNBT(NBTTagCompound tag)
-	{
-	    this.reset();
-	    
-		name = tag.getString("name");
-		weight = Math.max(tag.getInteger("weight"), 1);
-		
-		// Old entries that were never given IDs
-		List<LootEntry> legacyEntry = new ArrayList<>();
-		
-		NBTTagList jRew = tag.getTagList("rewards", 10);
-		for(int i = 0; i < jRew.tagCount(); i++)
-		{
-			NBTTagCompound entry = jRew.getCompoundTagAt(i);
-			int id = entry.hasKey("ID", 99) ? entry.getInteger("ID") : -1;
-			
-			LootEntry loot = new LootEntry();
-			loot.readFromNBT(entry);
-			
-			if(id >= 0)
-            {
+public class LootGroup extends SimpleDatabase<LootEntry> implements INBTSaveLoad<NBTTagCompound> {
+    public String name = "Loot Group";
+    public int weight = 1;
+
+    public List<BigItemStack> getRandomReward(Random rand) {
+        int total = getTotalWeight();
+        float r = rand.nextFloat() * total;
+        int cnt = 0;
+
+        for (DBEntry<LootEntry> entry : getEntries()) {
+            cnt += entry.getValue().weight;
+            if (cnt >= r) {
+                return entry.getValue().items;
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    public int getTotalWeight() {
+        int i = 0;
+
+        for (DBEntry<LootEntry> entry : getEntries()) {
+            i += entry.getValue().weight;
+        }
+
+        return i;
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound tag) {
+        this.reset();
+
+        name = tag.getString("name");
+        weight = Math.max(tag.getInteger("weight"), 1);
+
+        // Old entries that were never given IDs
+        List<LootEntry> legacyEntry = new ArrayList<>();
+
+        NBTTagList jRew = tag.getTagList("rewards", 10);
+        for (int i = 0; i < jRew.tagCount(); i++) {
+            NBTTagCompound entry = jRew.getCompoundTagAt(i);
+            int id = entry.hasKey("ID", 99) ? entry.getInteger("ID") : -1;
+
+            LootEntry loot = new LootEntry();
+            loot.readFromNBT(entry);
+
+            if (id >= 0) {
                 this.add(id, loot);
-            } else
-            {
+            } else {
                 legacyEntry.add(loot);
             }
-		}
-		
-		for(LootEntry entry : legacyEntry)
-        {
+        }
+
+        for (LootEntry entry : legacyEntry) {
             this.add(this.nextID(), entry);
         }
-	}
-	
-	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound tag)
-	{
-		tag.setString("name", name);
-		tag.setInteger("weight", weight);
-		
-		NBTTagList jRew = new NBTTagList();
-		for(DBEntry<LootEntry> entry : getEntries())
-		{
-			if(entry == null) continue;
-			
-			NBTTagCompound jLoot = entry.getValue().writeToNBT(new NBTTagCompound());
-			jLoot.setInteger("ID", entry.getID());
-			jRew.appendTag(jLoot);
-		}
-		tag.setTag("rewards", jRew);
-		
-		return tag;
-	}
-	
-	public static class LootEntry implements INBTSaveLoad<NBTTagCompound>
-	{
-		public int weight = 1;
-		public final List<BigItemStack> items = new ArrayList<>();
-		
-		@Override
-		public void readFromNBT(NBTTagCompound json)
-		{
-			weight = json.getInteger("weight");
-			weight = Math.max(1, weight);
-			
-			items.clear();
-			NBTTagList jItm = json.getTagList("items", 10);
-			for(int i = 0; i < jItm.tagCount(); i++)
-			{
-				items.add(JsonHelper.JsonToItemStack(jItm.getCompoundTagAt(i)));
-			}
-		}
-		
-		@Override
-		public NBTTagCompound writeToNBT(NBTTagCompound tag)
-		{
-			tag.setInteger("weight", weight);
-			
-			NBTTagList jItm = new NBTTagList();
-			for(BigItemStack stack : items)
-			{
-				jItm.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
-			}
-			tag.setTag("items", jItm);
-			
-			return tag;
-		}
-	}
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound tag) {
+        tag.setString("name", name);
+        tag.setInteger("weight", weight);
+
+        NBTTagList jRew = new NBTTagList();
+        for (DBEntry<LootEntry> entry : getEntries()) {
+            if (entry == null) continue;
+
+            NBTTagCompound jLoot = entry.getValue().writeToNBT(new NBTTagCompound());
+            jLoot.setInteger("ID", entry.getID());
+            jRew.appendTag(jLoot);
+        }
+        tag.setTag("rewards", jRew);
+
+        return tag;
+    }
+
+    public static class LootEntry implements INBTSaveLoad<NBTTagCompound> {
+        public int weight = 1;
+        public final List<BigItemStack> items = new ArrayList<>();
+
+        @Override
+        public void readFromNBT(NBTTagCompound json) {
+            weight = json.getInteger("weight");
+            weight = Math.max(1, weight);
+
+            items.clear();
+            NBTTagList jItm = json.getTagList("items", 10);
+            for (int i = 0; i < jItm.tagCount(); i++) {
+                items.add(JsonHelper.JsonToItemStack(jItm.getCompoundTagAt(i)));
+            }
+        }
+
+        @Override
+        public NBTTagCompound writeToNBT(NBTTagCompound tag) {
+            tag.setInteger("weight", weight);
+
+            NBTTagList jItm = new NBTTagList();
+            for (BigItemStack stack : items) {
+                jItm.appendTag(JsonHelper.ItemStackToJson(stack, new NBTTagCompound()));
+            }
+            tag.setTag("items", jItm);
+
+            return tag;
+        }
+    }
 }

--- a/src/main/java/bq_standard/rewards/loot/LootRegistry.java
+++ b/src/main/java/bq_standard/rewards/loot/LootRegistry.java
@@ -3,112 +3,100 @@ package bq_standard.rewards.loot;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.storage.INBTPartial;
 import betterquesting.api2.storage.SimpleDatabase;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
+import javax.annotation.Nullable;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 
-public class LootRegistry extends SimpleDatabase<LootGroup> implements INBTPartial<NBTTagCompound, Integer>
-{
+public class LootRegistry extends SimpleDatabase<LootGroup> implements INBTPartial<NBTTagCompound, Integer> {
     // TODO: Add localised group names
     // TODO: Use a better UI updating method
     // TODO: Add claim limits and store by UUID
-    
+
     public static final LootRegistry INSTANCE = new LootRegistry();
-    
+
     private final Comparator<DBEntry<LootGroup>> groupSorter = Comparator.comparingInt(o -> o.getValue().weight);
-	public boolean updateUI = false;
-	
-	public synchronized LootGroup createNew(int id)
-    {
+    public boolean updateUI = false;
+
+    public synchronized LootGroup createNew(int id) {
         LootGroup group = new LootGroup();
-        if(id >= 0) this.add(id, group);
+        if (id >= 0) this.add(id, group);
         return group;
     }
-    
-    public int getTotalWeight()
-    {
+
+    public int getTotalWeight() {
         int i = 0;
-        
-        for(DBEntry<LootGroup> lg : this.getEntries())
-        {
+
+        for (DBEntry<LootGroup> lg : this.getEntries()) {
             i += lg.getValue().weight;
         }
-        
+
         return i;
     }
-    
+
     /**
-	 *
-	 * @param weight A value between 0 and 1 that represents how common this reward is (i.e. higher values mean rarer loot)
-	 * @param rand The random instance used to pick the group
-	 * @return a loot group with the corresponding rarity of loot
-	 */
-    public LootGroup getWeightedGroup(float weight, Random rand)
-    {
+     *
+     * @param weight A value between 0 and 1 that represents how common this reward is (i.e. higher values mean rarer loot)
+     * @param rand The random instance used to pick the group
+     * @return a loot group with the corresponding rarity of loot
+     */
+    public LootGroup getWeightedGroup(float weight, Random rand) {
         final int total = getTotalWeight();
-        
-        if(total <= 0) return null;
-		
-		float r = rand.nextFloat() * total/4F + weight*total*0.75F;
-		int cnt = 0;
-		
-		List<DBEntry<LootGroup>> sorted = new ArrayList<>(getEntries());
-		sorted.sort(groupSorter);
-		
-		for(DBEntry<LootGroup> entry : sorted)
-		{
-			cnt += entry.getValue().weight;
-			if(cnt >= r) return entry.getValue();
-		}
-		
-		return null;
+
+        if (total <= 0) return null;
+
+        float r = rand.nextFloat() * total / 4F + weight * total * 0.75F;
+        int cnt = 0;
+
+        List<DBEntry<LootGroup>> sorted = new ArrayList<>(getEntries());
+        sorted.sort(groupSorter);
+
+        for (DBEntry<LootGroup> entry : sorted) {
+            cnt += entry.getValue().weight;
+            if (cnt >= r) return entry.getValue();
+        }
+
+        return null;
     }
-    
+
     @Override
-    public synchronized NBTTagCompound writeToNBT(NBTTagCompound tag, @Nullable List<Integer> subset)
-    {
-		NBTTagList jRew = new NBTTagList();
-		for(DBEntry<LootGroup> entry : getEntries())
-		{
-		    if(subset != null && !subset.contains(entry.getID())) continue;
-			NBTTagCompound jGrp = entry.getValue().writeToNBT(new NBTTagCompound());
-			jGrp.setInteger("ID", entry.getID());
-			jRew.appendTag(jGrp);
-		}
-		tag.setTag("groups", jRew);
-		
+    public synchronized NBTTagCompound writeToNBT(NBTTagCompound tag, @Nullable List<Integer> subset) {
+        NBTTagList jRew = new NBTTagList();
+        for (DBEntry<LootGroup> entry : getEntries()) {
+            if (subset != null && !subset.contains(entry.getID())) continue;
+            NBTTagCompound jGrp = entry.getValue().writeToNBT(new NBTTagCompound());
+            jGrp.setInteger("ID", entry.getID());
+            jRew.appendTag(jGrp);
+        }
+        tag.setTag("groups", jRew);
+
         return tag;
     }
-    
+
     @Override
-    public synchronized void readFromNBT(NBTTagCompound tag, boolean merge)
-    {
-		if(!merge) this.reset();
-		
-		List<LootGroup> legacyGroups = new ArrayList<>();
-		
-		NBTTagList list = tag.getTagList("groups", 10);
-		for(int i = 0; i < list.tagCount(); i++)
-		{
-			NBTTagCompound entry = list.getCompoundTagAt(i);
-			int id = entry.hasKey("ID", 99) ? entry.getInteger("ID") : -1;
-			
-			LootGroup group = getValue(id);
-			if(group == null) group = createNew(id);
-			group.readFromNBT(entry);
-			if(id < 0) legacyGroups.add(group);
-		}
-		
-		for(LootGroup group : legacyGroups)
-        {
+    public synchronized void readFromNBT(NBTTagCompound tag, boolean merge) {
+        if (!merge) this.reset();
+
+        List<LootGroup> legacyGroups = new ArrayList<>();
+
+        NBTTagList list = tag.getTagList("groups", 10);
+        for (int i = 0; i < list.tagCount(); i++) {
+            NBTTagCompound entry = list.getCompoundTagAt(i);
+            int id = entry.hasKey("ID", 99) ? entry.getInteger("ID") : -1;
+
+            LootGroup group = getValue(id);
+            if (group == null) group = createNew(id);
+            group.readFromNBT(entry);
+            if (id < 0) legacyGroups.add(group);
+        }
+
+        for (LootGroup group : legacyGroups) {
             this.add(this.nextID(), group);
         }
-		
-		updateUI = true;
+
+        updateUI = true;
     }
 }

--- a/src/main/java/bq_standard/tasks/ITaskInventory.java
+++ b/src/main/java/bq_standard/tasks/ITaskInventory.java
@@ -4,10 +4,8 @@ import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.ParticipantInfo;
-
 import javax.annotation.Nonnull;
 
-public interface ITaskInventory extends ITask
-{
+public interface ITaskInventory extends ITask {
     void onInventoryChange(@Nonnull DBEntry<IQuest> quest, @Nonnull ParticipantInfo pInfo);
 }

--- a/src/main/java/bq_standard/tasks/ITaskItemInput.java
+++ b/src/main/java/bq_standard/tasks/ITaskItemInput.java
@@ -2,7 +2,6 @@ package bq_standard.tasks;
 
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api.utils.BigItemStack;
-
 import java.util.List;
 
 public interface ITaskItemInput extends ITask {

--- a/src/main/java/bq_standard/tasks/ITaskTickable.java
+++ b/src/main/java/bq_standard/tasks/ITaskTickable.java
@@ -4,10 +4,8 @@ import betterquesting.api.questing.IQuest;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api2.storage.DBEntry;
 import betterquesting.api2.utils.ParticipantInfo;
-
 import javax.annotation.Nonnull;
 
-public interface ITaskTickable extends ITask
-{
+public interface ITaskTickable extends ITask {
     void tickTask(@Nonnull ParticipantInfo pInfo, @Nonnull DBEntry<IQuest> quest);
 }

--- a/src/main/java/bq_standard/tasks/TaskBlockBreak.java
+++ b/src/main/java/bq_standard/tasks/TaskBlockBreak.java
@@ -14,6 +14,10 @@ import bq_standard.tasks.base.TaskProgressableBase;
 import bq_standard.tasks.factory.FactoryTaskBlockBreak;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import net.minecraft.block.Block;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.init.Blocks;
@@ -26,11 +30,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.oredict.OreDictionary;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 
 public class TaskBlockBreak extends TaskProgressableBase<int[]> {
     // region Properties
@@ -165,11 +164,15 @@ public class TaskBlockBreak extends TaskProgressableBase<int[]> {
         for (int i = 0; i < blockTypes.size(); i++) {
             NbtBlockType targetBlock = blockTypes.get(i);
 
-            int tmpMeta = (targetBlock.m < 0 || targetBlock.m == OreDictionary.WILDCARD_VALUE) ? OreDictionary.WILDCARD_VALUE : meta;
-            boolean oreMatch = targetBlock.oreDict.length() > 0 && OreDictionary.getOres(targetBlock.oreDict).contains(new ItemStack(block, 1, tmpMeta));
+            int tmpMeta = (targetBlock.m < 0 || targetBlock.m == OreDictionary.WILDCARD_VALUE)
+                    ? OreDictionary.WILDCARD_VALUE
+                    : meta;
+            boolean oreMatch = targetBlock.oreDict.length() > 0
+                    && OreDictionary.getOres(targetBlock.oreDict).contains(new ItemStack(block, 1, tmpMeta));
             final int index = i;
 
-            if ((oreMatch || (block == targetBlock.b && (targetBlock.m < 0 || meta == targetBlock.m))) && ItemComparison.CompareNBTTag(targetBlock.tags, tags, true)) {
+            if ((oreMatch || (block == targetBlock.b && (targetBlock.m < 0 || meta == targetBlock.m)))
+                    && ItemComparison.CompareNBTTag(targetBlock.tags, tags, true)) {
                 progress.forEach((entry) -> {
                     if (entry.getSecond()[index] >= targetBlock.n) return;
                     entry.getSecond()[index]++;

--- a/src/main/java/bq_standard/tasks/TaskCheckbox.java
+++ b/src/main/java/bq_standard/tasks/TaskCheckbox.java
@@ -23,8 +23,7 @@ public class TaskCheckbox extends TaskBase {
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound nbt) {
-    }
+    public void readFromNBT(NBTTagCompound nbt) {}
     // endregion Properties
 
     // region Basic
@@ -52,6 +51,5 @@ public class TaskCheckbox extends TaskBase {
     // endregion Basic
 
     @Override
-    public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
-    }
+    public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {}
 }

--- a/src/main/java/bq_standard/tasks/TaskCrafting.java
+++ b/src/main/java/bq_standard/tasks/TaskCrafting.java
@@ -16,6 +16,11 @@ import bq_standard.tasks.base.TaskProgressableBase;
 import bq_standard.tasks.factory.FactoryTaskCrafting;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.IntSupplier;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
@@ -25,12 +30,6 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.Constants;
 import org.apache.logging.log4j.Level;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.IntSupplier;
 
 public class TaskCrafting extends TaskProgressableBase<int[]> implements ITaskItemInput {
     // region Properties
@@ -149,7 +148,8 @@ public class TaskCrafting extends TaskProgressableBase<int[]> implements ITaskIt
         pInfo.markDirtyParty(Collections.singletonList(quest.getID()));
     }
 
-    public void onItemCraft(ParticipantInfo pInfo, DBEntry<IQuest> quest, ItemStack stack, IntSupplier realStackSizeSupplier) {
+    public void onItemCraft(
+            ParticipantInfo pInfo, DBEntry<IQuest> quest, ItemStack stack, IntSupplier realStackSizeSupplier) {
         if (!allowCraft) return;
         onItemInternal(pInfo, quest, stack, realStackSizeSupplier);
     }
@@ -168,7 +168,8 @@ public class TaskCrafting extends TaskProgressableBase<int[]> implements ITaskIt
         onItemInternal(pInfo, quest, stack, null);
     }
 
-    private void onItemInternal(ParticipantInfo pInfo, DBEntry<IQuest> quest, ItemStack stack, IntSupplier realStackSizeSupplier) {
+    private void onItemInternal(
+            ParticipantInfo pInfo, DBEntry<IQuest> quest, ItemStack stack, IntSupplier realStackSizeSupplier) {
         // ignore null stack
         // ignore negatively sized stack only if it's indeed the real stack size
         if (stack == null || (stack.stackSize <= 0 && realStackSizeSupplier == null)) return;
@@ -181,7 +182,9 @@ public class TaskCrafting extends TaskProgressableBase<int[]> implements ITaskIt
             final BigItemStack rStack = requiredItems.get(i);
             final int index = i;
 
-            if (ItemComparison.StackMatch(rStack.getBaseStack(), stack, !ignoreNBT, partialMatch) || ItemComparison.OreDictionaryMatch(rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !ignoreNBT, partialMatch)) {
+            if (ItemComparison.StackMatch(rStack.getBaseStack(), stack, !ignoreNBT, partialMatch)
+                    || ItemComparison.OreDictionaryMatch(
+                            rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !ignoreNBT, partialMatch)) {
                 int realStackSize;
                 if (realStackSizeCache < 0) {
                     realStackSize = realStackSizeSupplier.getAsInt();
@@ -193,8 +196,9 @@ public class TaskCrafting extends TaskProgressableBase<int[]> implements ITaskIt
                     realStackSize = realStackSizeCache;
                 }
                 progress.stream()
-                    .filter(e -> e.getSecond()[index] < rStack.stackSize)
-                    .forEach(e -> e.getSecond()[index] = Math.min(e.getSecond()[index] + realStackSize, rStack.stackSize));
+                        .filter(e -> e.getSecond()[index] < rStack.stackSize)
+                        .forEach(e -> e.getSecond()[index] =
+                                Math.min(e.getSecond()[index] + realStackSize, rStack.stackSize));
                 changed = true;
             }
         }

--- a/src/main/java/bq_standard/tasks/TaskCrafting.java
+++ b/src/main/java/bq_standard/tasks/TaskCrafting.java
@@ -1,5 +1,6 @@
 package bq_standard.tasks;
 
+import betterquesting.api.api.QuestingAPI;
 import betterquesting.api.questing.IQuest;
 import betterquesting.api.utils.BigItemStack;
 import betterquesting.api.utils.ItemComparison;
@@ -22,11 +23,15 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.IntSupplier;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTBase.NBTPrimitive;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.stats.StatList;
+import net.minecraft.stats.StatisticsFile;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.Constants;
 import org.apache.logging.log4j.Level;
@@ -39,12 +44,15 @@ public class TaskCrafting extends TaskProgressableBase<int[]> implements ITaskIt
     public boolean allowAnvil = false;
     public boolean allowSmelt = true;
     public boolean allowCraft = true;
+    public boolean allowCraftedFromStatistics = false;
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         partialMatch = nbt.getBoolean("partialMatch");
         ignoreNBT = nbt.getBoolean("ignoreNBT");
         if (nbt.hasKey("allowCraft")) allowCraft = nbt.getBoolean("allowCraft");
+        if (nbt.hasKey("allowCraftedFromStatistics"))
+            allowCraftedFromStatistics = nbt.getBoolean("allowCraftedFromStatistics");
         if (nbt.hasKey("allowSmelt")) allowSmelt = nbt.getBoolean("allowSmelt");
         if (nbt.hasKey("allowAnvil")) allowAnvil = nbt.getBoolean("allowAnvil");
 
@@ -60,6 +68,7 @@ public class TaskCrafting extends TaskProgressableBase<int[]> implements ITaskIt
         nbt.setBoolean("partialMatch", partialMatch);
         nbt.setBoolean("ignoreNBT", ignoreNBT);
         nbt.setBoolean("allowCraft", allowCraft);
+        nbt.setBoolean("allowCraftedFromStatistics", allowCraftedFromStatistics);
         nbt.setBoolean("allowSmelt", allowSmelt);
         nbt.setBoolean("allowAnvil", allowAnvil);
 
@@ -138,11 +147,36 @@ public class TaskCrafting extends TaskProgressableBase<int[]> implements ITaskIt
             if (isComplete(uuid)) return;
 
             int[] tmp = getUsersProgress(uuid);
+            boolean progressChanged = false;
+            boolean completed = true;
             for (int i = 0; i < requiredItems.size(); i++) {
                 BigItemStack rStack = requiredItems.get(i);
-                if (tmp[i] < rStack.stackSize) return;
+                EntityPlayerMP player;
+                if ((tmp[i] < rStack.stackSize)
+                        && allowCraftedFromStatistics
+                        && (player = QuestingAPI.getPlayer(uuid)) != null) {
+                    StatisticsFile stats = player.func_147099_x();
+                    int itemId = Item.getIdFromItem(rStack.getBaseStack().getItem());
+                    if (itemId < StatList.objectCraftStats.length && StatList.objectCraftStats[itemId] != null) {
+                        // This has a very misleading deobf name, writeStat looks up the given stat in the hashmap and
+                        // returns it as an int.
+                        int alreadyCrafted = stats.writeStat(StatList.objectCraftStats[itemId]);
+                        if (alreadyCrafted > tmp[i]) {
+                            tmp[i] = alreadyCrafted;
+                            progressChanged = true;
+                        }
+                    }
+                }
+                if (tmp[i] < rStack.stackSize) {
+                    completed = false;
+                }
             }
-            setComplete(uuid);
+            if (progressChanged) {
+                setUserProgress(uuid, tmp);
+            }
+            if (completed) {
+                setComplete(uuid);
+            }
         });
 
         pInfo.markDirtyParty(Collections.singletonList(quest.getID()));

--- a/src/main/java/bq_standard/tasks/TaskFluid.java
+++ b/src/main/java/bq_standard/tasks/TaskFluid.java
@@ -15,6 +15,15 @@ import bq_standard.tasks.base.TaskProgressableBase;
 import bq_standard.tasks.factory.FactoryTaskFluid;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -28,20 +37,10 @@ import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.BiFunction;
-import java.util.function.IntFunction;
-import java.util.stream.IntStream;
-
 public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInventory, IFluidTask, IItemTask {
     // region Properties
     public final List<FluidStack> requiredFluids = new ArrayList<>();
-    //public boolean partialMatch = true; // Not many ideal ways of implementing this with fluid handlers
+    // public boolean partialMatch = true; // Not many ideal ways of implementing this with fluid handlers
     public boolean ignoreNbt = true;
     public boolean consume = true;
     public boolean groupDetect = false;
@@ -49,7 +48,7 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
-        //partialMatch = json.getBoolean("partialMatch");
+        // partialMatch = json.getBoolean("partialMatch");
         ignoreNbt = nbt.getBoolean("ignoreNBT");
         consume = nbt.getBoolean("consume");
         groupDetect = nbt.getBoolean("groupDetect");
@@ -64,7 +63,7 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
 
     @Override
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-        //json.setBoolean("partialMatch", partialMatch);
+        // json.setBoolean("partialMatch", partialMatch);
         nbt.setBoolean("ignoreNBT", ignoreNbt);
         nbt.setBoolean("consume", consume);
         nbt.setBoolean("groupDetect", groupDetect);
@@ -164,7 +163,8 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
     }
 
     private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync) {
-        final List<Tuple2<UUID, int[]>> progress = getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
+        final List<Tuple2<UUID, int[]>> progress =
+                getBulkProgress(consume ? Collections.singletonList(pInfo.UUID) : pInfo.ALL_UUIDS);
         boolean updated = resync;
 
         topLoop:
@@ -250,7 +250,12 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
     // region IFluidTask
     @Override
     public boolean canAcceptFluid(UUID owner, DBEntry<IQuest> quest, FluidStack fluid) {
-        if (owner == null || fluid == null || fluid.getFluid() == null || !consume || isComplete(owner) || requiredFluids.size() <= 0) {
+        if (owner == null
+                || fluid == null
+                || fluid.getFluid() == null
+                || !consume
+                || isComplete(owner)
+                || requiredFluids.size() <= 0) {
             return false;
         }
 
@@ -267,7 +272,12 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
 
     @Override
     public FluidStack submitFluid(UUID owner, DBEntry<IQuest> quest, FluidStack input) {
-        if (owner == null || input == null || input.amount <= 0 || !consume || isComplete(owner) || requiredFluids.size() <= 0) {
+        if (owner == null
+                || input == null
+                || input.amount <= 0
+                || !consume
+                || isComplete(owner)
+                || requiredFluids.size() <= 0) {
             return input;
         }
 
@@ -329,7 +339,7 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
 
         Detector detector = new Detector(this, Collections.singletonList(owner));
 
-        final ItemStack[] wrapper = new ItemStack[]{input.copy()};
+        final ItemStack[] wrapper = new ItemStack[] {input.copy()};
 
         detector.run(wrapper[0], (drain, drainAmount) -> {
             if (wrapper[0].getItem() instanceof IFluidContainerItem) {
@@ -401,7 +411,8 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
 
         public Detector(TaskFluid task, @Nonnull List<UUID> uuids) {
             this.task = task;
-            // Removing the consume check here would make the task cheaper on groups and for that reason sharing is restricted to detect only
+            // Removing the consume check here would make the task cheaper on groups and for that reason sharing is
+            // restricted to detect only
             this.progress = task.getBulkProgress(uuids);
             if (!task.consume) {
                 if (task.groupDetect) // Reset all detect progress
@@ -445,7 +456,7 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
                     int remaining = rStack.amount - value.getSecond()[i];
 
                     FluidStack drain = rStack.copy();
-                    drain.amount = remaining; //drain.amount = remaining / stack.stackSize;
+                    drain.amount = remaining; // drain.amount = remaining / stack.stackSize;
                     if (task.ignoreNbt) drain.tag = null;
                     if (drain.amount <= 0) continue;
 
@@ -485,7 +496,7 @@ public class TaskFluid extends TaskProgressableBase<int[]> implements ITaskInven
                         }
                     } else {
                         FluidStack drain = rStack.copy();
-                        drain.amount = remaining; //drain.amount = remaining / stack.stackSize;
+                        drain.amount = remaining; // drain.amount = remaining / stack.stackSize;
                         if (task.ignoreNbt) drain.tag = null;
                         if (drain.amount <= 0) continue;
 

--- a/src/main/java/bq_standard/tasks/TaskHunt.java
+++ b/src/main/java/bq_standard/tasks/TaskHunt.java
@@ -14,6 +14,9 @@ import bq_standard.tasks.base.TaskProgressableBase;
 import bq_standard.tasks.factory.FactoryTaskHunt;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -21,10 +24,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 
 public class TaskHunt extends TaskProgressableBase<Integer> {
     // region Properties
@@ -104,7 +103,6 @@ public class TaskHunt extends TaskProgressableBase<Integer> {
     }
     // endregion Progress
 
-
     @Override
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
         final List<Tuple2<UUID, Integer>> progress = getBulkProgress(pInfo.ALL_UUIDS);
@@ -117,7 +115,8 @@ public class TaskHunt extends TaskProgressableBase<Integer> {
     }
 
     @SuppressWarnings({"unchecked", "DuplicatedCode"})
-    public void onKilledByPlayer(ParticipantInfo pInfo, DBEntry<IQuest> quest, EntityLivingBase entity, DamageSource source) {
+    public void onKilledByPlayer(
+            ParticipantInfo pInfo, DBEntry<IQuest> quest, EntityLivingBase entity, DamageSource source) {
         if (damageType.length() > 0 && (source == null || !damageType.equalsIgnoreCase(source.damageType))) return;
 
         Class<? extends Entity> subject = entity.getClass();

--- a/src/main/java/bq_standard/tasks/TaskInteractEntity.java
+++ b/src/main/java/bq_standard/tasks/TaskInteractEntity.java
@@ -14,6 +14,11 @@ import bq_standard.tasks.base.TaskProgressableBase;
 import bq_standard.tasks.factory.FactoryTaskInteractEntity;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nullable;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -21,16 +26,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 public class TaskInteractEntity extends TaskProgressableBase<Integer> {
     // region Properties
     @Nullable
     public BigItemStack targetItem = null;
+
     public boolean ignoreItemNBT = false;
     public boolean partialItemMatch = true;
 
@@ -120,7 +120,6 @@ public class TaskInteractEntity extends TaskProgressableBase<Integer> {
     }
     // endregion Progress
 
-
     @Override
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
         final List<Tuple2<UUID, Integer>> progress = getBulkProgress(pInfo.ALL_UUIDS);
@@ -152,7 +151,13 @@ public class TaskInteractEntity extends TaskProgressableBase<Integer> {
         }
 
         if (targetItem != null) {
-            if (targetItem.hasOreDict() && !ItemComparison.OreDictionaryMatch(targetItem.getOreIngredient(), targetItem.GetTagCompound(), item, !ignoreItemNBT, partialItemMatch)) {
+            if (targetItem.hasOreDict()
+                    && !ItemComparison.OreDictionaryMatch(
+                            targetItem.getOreIngredient(),
+                            targetItem.GetTagCompound(),
+                            item,
+                            !ignoreItemNBT,
+                            partialItemMatch)) {
                 return;
             } else if (!ItemComparison.StackMatch(targetItem.getBaseStack(), item, !ignoreItemNBT, partialItemMatch)) {
                 return;

--- a/src/main/java/bq_standard/tasks/TaskInteractItem.java
+++ b/src/main/java/bq_standard/tasks/TaskInteractItem.java
@@ -15,6 +15,11 @@ import bq_standard.tasks.base.TaskProgressableBase;
 import bq_standard.tasks.factory.FactoryTaskInteractItem;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nullable;
 import net.minecraft.block.Block;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.init.Blocks;
@@ -24,16 +29,11 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.oredict.OreDictionary;
 
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 public class TaskInteractItem extends TaskProgressableBase<Integer> {
     // region Properties
     @Nullable
     public BigItemStack targetItem = null;
+
     public final NbtBlockType targetBlock = new NbtBlockType(null);
     public boolean partialMatch = true;
     public boolean ignoreNBT = true;
@@ -108,7 +108,6 @@ public class TaskInteractItem extends TaskProgressableBase<Integer> {
     }
     // endregion Progress
 
-
     @Override
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
         final List<Tuple2<UUID, Integer>> progress = getBulkProgress(pInfo.ALL_UUIDS);
@@ -121,7 +120,16 @@ public class TaskInteractItem extends TaskProgressableBase<Integer> {
     }
 
     @SuppressWarnings("DuplicatedCode")
-    public void onInteract(ParticipantInfo pInfo, DBEntry<IQuest> quest, ItemStack item, Block block, int meta, int x, int y, int z, boolean isHit) {
+    public void onInteract(
+            ParticipantInfo pInfo,
+            DBEntry<IQuest> quest,
+            ItemStack item,
+            Block block,
+            int meta,
+            int x,
+            int y,
+            int z,
+            boolean isHit) {
         if ((!onHit && isHit) || (!onInteract && !isHit)) return;
 
         if (targetBlock.b != Blocks.air && targetBlock.b != null) {
@@ -133,16 +141,26 @@ public class TaskInteractItem extends TaskProgressableBase<Integer> {
                 tile.writeToNBT(tags);
             }
 
-            int tmpMeta = (targetBlock.m < 0 || targetBlock.m == OreDictionary.WILDCARD_VALUE) ? OreDictionary.WILDCARD_VALUE : meta;
-            boolean oreMatch = targetBlock.oreDict.length() > 0 && OreDictionary.getOres(targetBlock.oreDict).contains(new ItemStack(block, 1, tmpMeta));
+            int tmpMeta = (targetBlock.m < 0 || targetBlock.m == OreDictionary.WILDCARD_VALUE)
+                    ? OreDictionary.WILDCARD_VALUE
+                    : meta;
+            boolean oreMatch = targetBlock.oreDict.length() > 0
+                    && OreDictionary.getOres(targetBlock.oreDict).contains(new ItemStack(block, 1, tmpMeta));
 
-            if ((!oreMatch && (block != targetBlock.b || (targetBlock.m >= 0 && meta != targetBlock.m))) || !ItemComparison.CompareNBTTag(targetBlock.tags, tags, true)) {
+            if ((!oreMatch && (block != targetBlock.b || (targetBlock.m >= 0 && meta != targetBlock.m)))
+                    || !ItemComparison.CompareNBTTag(targetBlock.tags, tags, true)) {
                 return;
             }
         }
 
         if (targetItem != null) {
-            if (targetItem.hasOreDict() && !ItemComparison.OreDictionaryMatch(targetItem.getOreIngredient(), targetItem.GetTagCompound(), item, !ignoreNBT, partialMatch)) {
+            if (targetItem.hasOreDict()
+                    && !ItemComparison.OreDictionaryMatch(
+                            targetItem.getOreIngredient(),
+                            targetItem.GetTagCompound(),
+                            item,
+                            !ignoreNBT,
+                            partialMatch)) {
                 return;
             } else if (!ItemComparison.StackMatch(targetItem.getBaseStack(), item, !ignoreNBT, partialMatch)) {
                 return;

--- a/src/main/java/bq_standard/tasks/TaskLocation.java
+++ b/src/main/java/bq_standard/tasks/TaskLocation.java
@@ -11,6 +11,10 @@ import bq_standard.tasks.factory.FactoryTaskLocation;
 import codechicken.lib.math.MathHelper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import javax.annotation.Nonnull;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -23,11 +27,6 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.WorldProvider;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.Constants;
-
-import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 
 public class TaskLocation extends TaskBase implements ITaskTickable {
     // region Static
@@ -140,13 +139,29 @@ public class TaskLocation extends TaskBase implements ITaskTickable {
         boolean flag = false;
 
         if (playerMP.dimension == dim && (range <= 0 || getDistance(playerMP) <= range)) {
-            if (biome >= 0 && biome != playerMP.getServerForPlayer().getBiomeGenForCoords(MathHelper.floor_double(playerMP.posX), MathHelper.floor_double(playerMP.posZ)).biomeID) {
+            if (biome >= 0
+                    && biome
+                            != playerMP.getServerForPlayer()
+                                    .getBiomeGenForCoords(
+                                            MathHelper.floor_double(playerMP.posX),
+                                            MathHelper.floor_double(playerMP.posZ))
+                                    .biomeID) {
                 if (!invert) return;
-            } else if (!StringUtils.isNullOrEmpty(structure) && playerMP.getServerForPlayer().getChunkProvider().func_147416_a(playerMP.getServerForPlayer(), structure, MathHelper.floor_double(playerMP.posX), MathHelper.floor_double(playerMP.posY), MathHelper.floor_double(playerMP.posZ)) == null) {
+            } else if (!StringUtils.isNullOrEmpty(structure)
+                    && playerMP.getServerForPlayer()
+                                    .getChunkProvider()
+                                    .func_147416_a(
+                                            playerMP.getServerForPlayer(),
+                                            structure,
+                                            MathHelper.floor_double(playerMP.posX),
+                                            MathHelper.floor_double(playerMP.posY),
+                                            MathHelper.floor_double(playerMP.posZ))
+                            == null) {
                 if (!invert) return;
             } else if (visible && range > 0) // Do not do ray casting with infinite range!
             {
-                Vec3 pPos = Vec3.createVectorHelper(playerMP.posX, playerMP.posY + playerMP.getEyeHeight(), playerMP.posZ);
+                Vec3 pPos =
+                        Vec3.createVectorHelper(playerMP.posX, playerMP.posY + playerMP.getEyeHeight(), playerMP.posZ);
                 Vec3 tPos = Vec3.createVectorHelper(x, y, z);
                 MovingObjectPosition mop = playerMP.worldObj.func_147447_a(pPos, tPos, false, true, false);
 

--- a/src/main/java/bq_standard/tasks/TaskMeeting.java
+++ b/src/main/java/bq_standard/tasks/TaskMeeting.java
@@ -12,15 +12,14 @@ import bq_standard.tasks.base.TaskBase;
 import bq_standard.tasks.factory.FactoryTaskMeeting;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
-
-import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.List;
 
 public class TaskMeeting extends TaskBase implements ITaskTickable {
     // region Properties
@@ -87,7 +86,8 @@ public class TaskMeeting extends TaskBase implements ITaskTickable {
         if (!pInfo.PLAYER.isEntityAlive()) return;
 
         //noinspection unchecked
-        List<Entity> list = pInfo.PLAYER.worldObj.getEntitiesWithinAABBExcludingEntity(pInfo.PLAYER, pInfo.PLAYER.boundingBox.expand(range, range, range));
+        List<Entity> list = pInfo.PLAYER.worldObj.getEntitiesWithinAABBExcludingEntity(
+                pInfo.PLAYER, pInfo.PLAYER.boundingBox.expand(range, range, range));
         //noinspection unchecked
         Class<? extends Entity> target = (Class<? extends Entity>) EntityList.stringToClassMapping.get(idName);
         if (target == null) return;

--- a/src/main/java/bq_standard/tasks/TaskOptionalRetrieval.java
+++ b/src/main/java/bq_standard/tasks/TaskOptionalRetrieval.java
@@ -2,9 +2,8 @@ package bq_standard.tasks;
 
 import bq_standard.core.BQ_Standard;
 import bq_standard.tasks.factory.FactoryTaskOptionalRetrieval;
-import net.minecraft.util.ResourceLocation;
-
 import java.util.UUID;
+import net.minecraft.util.ResourceLocation;
 
 public class TaskOptionalRetrieval extends TaskRetrieval {
 

--- a/src/main/java/bq_standard/tasks/TaskRetrieval.java
+++ b/src/main/java/bq_standard/tasks/TaskRetrieval.java
@@ -17,6 +17,14 @@ import bq_standard.tasks.base.TaskProgressableBase;
 import bq_standard.tasks.factory.FactoryTaskRetrieval;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
@@ -26,15 +34,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.Constants;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.IntFunction;
-import java.util.stream.IntStream;
 
 public class TaskRetrieval extends TaskProgressableBase<int[]> implements ITaskInventory, IItemTask, ITaskItemInput {
     // region Properties
@@ -134,7 +133,6 @@ public class TaskRetrieval extends TaskProgressableBase<int[]> implements ITaskI
     }
     // endregion Progress
 
-
     @Override
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
         if (isComplete(pInfo.UUID)) return;
@@ -160,7 +158,8 @@ public class TaskRetrieval extends TaskProgressableBase<int[]> implements ITaskI
         checkAndComplete(pInfo, quest, detector.updated, detector.progress);
     }
 
-    private void checkAndComplete(ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync, List<Tuple2<UUID, int[]>> progress) {
+    private void checkAndComplete(
+            ParticipantInfo pInfo, DBEntry<IQuest> quest, boolean resync, List<Tuple2<UUID, int[]>> progress) {
         boolean updated = resync;
 
         topLoop:
@@ -192,7 +191,12 @@ public class TaskRetrieval extends TaskProgressableBase<int[]> implements ITaskI
     // region IItemTask
     @Override
     public boolean canAcceptItem(UUID owner, DBEntry<IQuest> quest, ItemStack stack) {
-        if (owner == null || stack == null || stack.stackSize <= 0 || !consume || isComplete(owner) || requiredItems.size() <= 0) {
+        if (owner == null
+                || stack == null
+                || stack.stackSize <= 0
+                || !consume
+                || isComplete(owner)
+                || requiredItems.size() <= 0) {
             return false;
         }
 
@@ -203,7 +207,9 @@ public class TaskRetrieval extends TaskProgressableBase<int[]> implements ITaskI
 
             if (progress[j] >= rStack.stackSize) continue;
 
-            if (ItemComparison.StackMatch(rStack.getBaseStack(), stack, !ignoreNBT, partialMatch) || ItemComparison.OreDictionaryMatch(rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !ignoreNBT, partialMatch)) {
+            if (ItemComparison.StackMatch(rStack.getBaseStack(), stack, !ignoreNBT, partialMatch)
+                    || ItemComparison.OreDictionaryMatch(
+                            rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !ignoreNBT, partialMatch)) {
                 return true;
             }
         }
@@ -279,6 +285,7 @@ public class TaskRetrieval extends TaskProgressableBase<int[]> implements ITaskI
          * List of (player uuid, [progress per required item])
          */
         public final List<Tuple2<UUID, int[]>> progress;
+
         private final int[] remCounts;
 
         public Detector(TaskRetrieval task, @Nonnull List<UUID> uuids) {
@@ -317,7 +324,12 @@ public class TaskRetrieval extends TaskProgressableBase<int[]> implements ITaskI
                 BigItemStack rStack = task.requiredItems.get(i);
 
                 if (!ItemComparison.StackMatch(rStack.getBaseStack(), stack, !task.ignoreNBT, task.partialMatch)
-                    && !ItemComparison.OreDictionaryMatch(rStack.getOreIngredient(), rStack.GetTagCompound(), stack, !task.ignoreNBT, task.partialMatch)) {
+                        && !ItemComparison.OreDictionaryMatch(
+                                rStack.getOreIngredient(),
+                                rStack.GetTagCompound(),
+                                stack,
+                                !task.ignoreNBT,
+                                task.partialMatch)) {
                     continue;
                 }
 

--- a/src/main/java/bq_standard/tasks/TaskScoreboard.java
+++ b/src/main/java/bq_standard/tasks/TaskScoreboard.java
@@ -13,6 +13,10 @@ import bq_standard.tasks.base.TaskBase;
 import bq_standard.tasks.factory.FactoryTaskScoreboard;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.scoreboard.IScoreObjectiveCriteria;
@@ -22,11 +26,6 @@ import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.Constants;
 import org.apache.logging.log4j.Level;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class TaskScoreboard extends TaskBase implements ITaskTickable {
     // region Properties
@@ -48,7 +47,8 @@ public class TaskScoreboard extends TaskBase implements ITaskTickable {
         conversion = nbt.getFloat("unitConversion");
         suffix = nbt.getString("unitSuffix");
         try {
-            operation = ScoreOperation.valueOf(nbt.hasKey("operation", Constants.NBT.TAG_STRING) ? nbt.getString("operation") : "MORE_OR_EQUAL");
+            operation = ScoreOperation.valueOf(
+                    nbt.hasKey("operation", Constants.NBT.TAG_STRING) ? nbt.getString("operation") : "MORE_OR_EQUAL");
         } catch (Exception e) {
             operation = ScoreOperation.MORE_OR_EQUAL;
         }
@@ -99,7 +99,8 @@ public class TaskScoreboard extends TaskBase implements ITaskTickable {
 
         if (scoreObj == null) {
             try {
-                IScoreObjectiveCriteria criteria = (IScoreObjectiveCriteria) IScoreObjectiveCriteria.field_96643_a.get(type);
+                IScoreObjectiveCriteria criteria =
+                        (IScoreObjectiveCriteria) IScoreObjectiveCriteria.field_96643_a.get(type);
                 criteria = criteria != null ? criteria : new ScoreDummyCriteria(scoreName);
                 scoreObj = board.addScoreObjective(scoreName, criteria);
                 scoreObj.setDisplayName(scoreDisp);
@@ -109,7 +110,8 @@ public class TaskScoreboard extends TaskBase implements ITaskTickable {
             }
         }
 
-        int points = board.func_96529_a(pInfo.PLAYER.getCommandSenderName(), scoreObj).getScorePoints();
+        int points = board.func_96529_a(pInfo.PLAYER.getCommandSenderName(), scoreObj)
+                .getScorePoints();
         ScoreboardBQ.INSTANCE.setScore(pInfo.UUID, scoreName, points);
 
         if (operation.checkValues(points, target)) {

--- a/src/main/java/bq_standard/tasks/TaskXP.java
+++ b/src/main/java/bq_standard/tasks/TaskXP.java
@@ -11,14 +11,13 @@ import bq_standard.tasks.base.TaskProgressableBase;
 import bq_standard.tasks.factory.FactoryTaskXP;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.Collections;
+import java.util.UUID;
+import javax.annotation.Nonnull;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.Constants;
-
-import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.UUID;
 
 public class TaskXP extends TaskProgressableBase<Long> implements ITaskTickable {
     // region Properties
@@ -84,7 +83,6 @@ public class TaskXP extends TaskProgressableBase<Long> implements ITaskTickable 
     }
     // endregion Progress
 
-
     @Override
     public void detect(ParticipantInfo pInfo, DBEntry<IQuest> quest) {
         if (isComplete(pInfo.UUID)) return;
@@ -114,7 +112,8 @@ public class TaskXP extends TaskProgressableBase<Long> implements ITaskTickable 
             changed = true;
         }
 
-        if (changed) // Needs to be here because even if no additional progress was added, a party memeber may have completed the task anyway
+        if (changed) // Needs to be here because even if no additional progress was added, a party memeber may have
+        // completed the task anyway
         {
             pInfo.markDirty(Collections.singletonList(quest.getID()));
         }

--- a/src/main/java/bq_standard/tasks/base/TaskBase.java
+++ b/src/main/java/bq_standard/tasks/base/TaskBase.java
@@ -3,18 +3,17 @@ package bq_standard.tasks.base;
 import betterquesting.api.questing.tasks.ITask;
 import betterquesting.api2.utils.DirtyPlayerMarker;
 import bq_standard.core.BQ_Standard;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraft.nbt.NBTTagString;
-import net.minecraftforge.common.util.Constants;
-import org.apache.logging.log4j.Level;
-
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import javax.annotation.Nullable;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTTagString;
+import net.minecraftforge.common.util.Constants;
+import org.apache.logging.log4j.Level;
 
 public abstract class TaskBase implements ITask {
     protected final Set<UUID> completeUsers = new TreeSet<>();
@@ -66,7 +65,8 @@ public abstract class TaskBase implements ITask {
         NBTTagList completeUsersNBTList = new NBTTagList();
 
         completeUsers.forEach((uuid) -> {
-            if (users == null || users.contains(uuid)) completeUsersNBTList.appendTag(new NBTTagString(uuid.toString()));
+            if (users == null || users.contains(uuid))
+                completeUsersNBTList.appendTag(new NBTTagString(uuid.toString()));
         });
 
         nbt.setTag("completeUsers", completeUsersNBTList);

--- a/src/main/java/bq_standard/tasks/base/TaskProgressableBase.java
+++ b/src/main/java/bq_standard/tasks/base/TaskProgressableBase.java
@@ -3,18 +3,17 @@ package bq_standard.tasks.base;
 import betterquesting.api2.utils.DirtyPlayerMarker;
 import betterquesting.api2.utils.Tuple2;
 import bq_standard.core.BQ_Standard;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraftforge.common.util.Constants;
-import org.apache.logging.log4j.Level;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.common.util.Constants;
+import org.apache.logging.log4j.Level;
 
 public abstract class TaskProgressableBase<T> extends TaskBase {
     protected final TreeMap<UUID, T> userProgress = new TreeMap<>();
@@ -46,11 +45,10 @@ public abstract class TaskProgressableBase<T> extends TaskBase {
         DirtyPlayerMarker.markDirty(dirtyPlayers);
     }
 
-
     protected List<Tuple2<UUID, T>> getBulkProgress(@Nonnull List<UUID> uuids) {
         return uuids.stream()
-            .map((uuid) -> new Tuple2<>(uuid, getUsersProgress(uuid)))
-            .collect(Collectors.toList());
+                .map((uuid) -> new Tuple2<>(uuid, getUsersProgress(uuid)))
+                .collect(Collectors.toList());
     }
 
     protected void setBulkProgress(@Nonnull List<Tuple2<UUID, T>> ProgressList) {

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskBlockBreak.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskBlockBreak.java
@@ -7,30 +7,25 @@ import bq_standard.tasks.TaskBlockBreak;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskBlockBreak implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskBlockBreak INSTANCE = new FactoryTaskBlockBreak();
-	
-	private final ResourceLocation REG_ID = new ResourceLocation(BQ_Standard.MODID, "block_break");
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return REG_ID;
-	}
+public class FactoryTaskBlockBreak implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskBlockBreak INSTANCE = new FactoryTaskBlockBreak();
 
-	@Override
-	public TaskBlockBreak createNew()
-	{
-		return new TaskBlockBreak();
-	}
+    private final ResourceLocation REG_ID = new ResourceLocation(BQ_Standard.MODID, "block_break");
 
-	@Override
-	public TaskBlockBreak loadFromData(NBTTagCompound json)
-	{
-		TaskBlockBreak task = new TaskBlockBreak();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public ResourceLocation getRegistryName() {
+        return REG_ID;
+    }
+
+    @Override
+    public TaskBlockBreak createNew() {
+        return new TaskBlockBreak();
+    }
+
+    @Override
+    public TaskBlockBreak loadFromData(NBTTagCompound json) {
+        TaskBlockBreak task = new TaskBlockBreak();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskCheckbox.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskCheckbox.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskCheckbox;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskCheckbox implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskCheckbox INSTANCE = new FactoryTaskCheckbox();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":checkbox");
-	}
+public class FactoryTaskCheckbox implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskCheckbox INSTANCE = new FactoryTaskCheckbox();
 
-	@Override
-	public TaskCheckbox createNew()
-	{
-		return new TaskCheckbox();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":checkbox");
+    }
 
-	@Override
-	public TaskCheckbox loadFromData(NBTTagCompound json)
-	{
-		TaskCheckbox task = new TaskCheckbox();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskCheckbox createNew() {
+        return new TaskCheckbox();
+    }
+
+    @Override
+    public TaskCheckbox loadFromData(NBTTagCompound json) {
+        TaskCheckbox task = new TaskCheckbox();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskCrafting.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskCrafting.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskCrafting;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskCrafting implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskCrafting INSTANCE = new FactoryTaskCrafting();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":crafting");
-	}
+public class FactoryTaskCrafting implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskCrafting INSTANCE = new FactoryTaskCrafting();
 
-	@Override
-	public TaskCrafting createNew()
-	{
-		return new TaskCrafting();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":crafting");
+    }
 
-	@Override
-	public TaskCrafting loadFromData(NBTTagCompound json)
-	{
-		TaskCrafting task = new TaskCrafting();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskCrafting createNew() {
+        return new TaskCrafting();
+    }
+
+    @Override
+    public TaskCrafting loadFromData(NBTTagCompound json) {
+        TaskCrafting task = new TaskCrafting();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskFluid.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskFluid.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskFluid;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskFluid implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskFluid INSTANCE = new FactoryTaskFluid();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":fluid");
-	}
+public class FactoryTaskFluid implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskFluid INSTANCE = new FactoryTaskFluid();
 
-	@Override
-	public TaskFluid createNew()
-	{
-		return new TaskFluid();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":fluid");
+    }
 
-	@Override
-	public TaskFluid loadFromData(NBTTagCompound json)
-	{
-		TaskFluid task = new TaskFluid();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskFluid createNew() {
+        return new TaskFluid();
+    }
+
+    @Override
+    public TaskFluid loadFromData(NBTTagCompound json) {
+        TaskFluid task = new TaskFluid();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskHunt.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskHunt.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskHunt;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskHunt implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskHunt INSTANCE = new FactoryTaskHunt();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":hunt");
-	}
+public class FactoryTaskHunt implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskHunt INSTANCE = new FactoryTaskHunt();
 
-	@Override
-	public TaskHunt createNew()
-	{
-		return new TaskHunt();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":hunt");
+    }
 
-	@Override
-	public TaskHunt loadFromData(NBTTagCompound json)
-	{
-		TaskHunt task = new TaskHunt();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskHunt createNew() {
+        return new TaskHunt();
+    }
+
+    @Override
+    public TaskHunt loadFromData(NBTTagCompound json) {
+        TaskHunt task = new TaskHunt();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskInteractEntity.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskInteractEntity.java
@@ -7,27 +7,23 @@ import bq_standard.tasks.TaskInteractEntity;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskInteractEntity implements IFactoryData<ITask, NBTTagCompound>
-{
+public class FactoryTaskInteractEntity implements IFactoryData<ITask, NBTTagCompound> {
     public static final FactoryTaskInteractEntity INSTANCE = new FactoryTaskInteractEntity();
-    
-	private final ResourceLocation REG_ID = new ResourceLocation(BQ_Standard.MODID, "interact_entity");
-	
+
+    private final ResourceLocation REG_ID = new ResourceLocation(BQ_Standard.MODID, "interact_entity");
+
     @Override
-    public ResourceLocation getRegistryName()
-    {
+    public ResourceLocation getRegistryName() {
         return REG_ID;
     }
-    
+
     @Override
-    public TaskInteractEntity createNew()
-    {
+    public TaskInteractEntity createNew() {
         return new TaskInteractEntity();
     }
-    
+
     @Override
-    public TaskInteractEntity loadFromData(NBTTagCompound nbt)
-    {
+    public TaskInteractEntity loadFromData(NBTTagCompound nbt) {
         TaskInteractEntity task = new TaskInteractEntity();
         task.readFromNBT(nbt);
         return task;

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskInteractItem.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskInteractItem.java
@@ -7,27 +7,23 @@ import bq_standard.tasks.TaskInteractItem;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskInteractItem implements IFactoryData<ITask, NBTTagCompound>
-{
+public class FactoryTaskInteractItem implements IFactoryData<ITask, NBTTagCompound> {
     public static final FactoryTaskInteractItem INSTANCE = new FactoryTaskInteractItem();
-    
-	private final ResourceLocation REG_ID = new ResourceLocation(BQ_Standard.MODID, "interact_item");
-	
+
+    private final ResourceLocation REG_ID = new ResourceLocation(BQ_Standard.MODID, "interact_item");
+
     @Override
-    public ResourceLocation getRegistryName()
-    {
+    public ResourceLocation getRegistryName() {
         return REG_ID;
     }
-    
+
     @Override
-    public TaskInteractItem createNew()
-    {
+    public TaskInteractItem createNew() {
         return new TaskInteractItem();
     }
-    
+
     @Override
-    public TaskInteractItem loadFromData(NBTTagCompound nbt)
-    {
+    public TaskInteractItem loadFromData(NBTTagCompound nbt) {
         TaskInteractItem task = new TaskInteractItem();
         task.readFromNBT(nbt);
         return task;

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskLocation.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskLocation.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskLocation;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskLocation implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskLocation INSTANCE = new FactoryTaskLocation();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":location");
-	}
+public class FactoryTaskLocation implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskLocation INSTANCE = new FactoryTaskLocation();
 
-	@Override
-	public TaskLocation createNew()
-	{
-		return new TaskLocation();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":location");
+    }
 
-	@Override
-	public TaskLocation loadFromData(NBTTagCompound json)
-	{
-		TaskLocation task = new TaskLocation();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskLocation createNew() {
+        return new TaskLocation();
+    }
+
+    @Override
+    public TaskLocation loadFromData(NBTTagCompound json) {
+        TaskLocation task = new TaskLocation();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskMeeting.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskMeeting.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskMeeting;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskMeeting implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskMeeting INSTANCE = new FactoryTaskMeeting();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":meeting");
-	}
+public class FactoryTaskMeeting implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskMeeting INSTANCE = new FactoryTaskMeeting();
 
-	@Override
-	public TaskMeeting createNew()
-	{
-		return new TaskMeeting();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":meeting");
+    }
 
-	@Override
-	public TaskMeeting loadFromData(NBTTagCompound json)
-	{
-		TaskMeeting task = new TaskMeeting();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskMeeting createNew() {
+        return new TaskMeeting();
+    }
+
+    @Override
+    public TaskMeeting loadFromData(NBTTagCompound json) {
+        TaskMeeting task = new TaskMeeting();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskOptionalRetrieval.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskOptionalRetrieval.java
@@ -12,23 +12,19 @@ public class FactoryTaskOptionalRetrieval implements IFactoryData<ITask, NBTTagC
     public static final FactoryTaskOptionalRetrieval INSTANCE = new FactoryTaskOptionalRetrieval();
 
     @Override
-    public ResourceLocation getRegistryName()
-    {
+    public ResourceLocation getRegistryName() {
         return new ResourceLocation(BQ_Standard.MODID + ":optional_retrieval");
     }
 
     @Override
-    public TaskOptionalRetrieval createNew()
-    {
+    public TaskOptionalRetrieval createNew() {
         return new TaskOptionalRetrieval();
     }
 
     @Override
-    public TaskOptionalRetrieval loadFromData(NBTTagCompound json)
-    {
+    public TaskOptionalRetrieval loadFromData(NBTTagCompound json) {
         TaskOptionalRetrieval task = new TaskOptionalRetrieval();
         task.readFromNBT(json);
         return task;
     }
-
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskRetrieval.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskRetrieval.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskRetrieval;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskRetrieval implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskRetrieval INSTANCE = new FactoryTaskRetrieval();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":retrieval");
-	}
+public class FactoryTaskRetrieval implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskRetrieval INSTANCE = new FactoryTaskRetrieval();
 
-	@Override
-	public TaskRetrieval createNew()
-	{
-		return new TaskRetrieval();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":retrieval");
+    }
 
-	@Override
-	public TaskRetrieval loadFromData(NBTTagCompound json)
-	{
-		TaskRetrieval task = new TaskRetrieval();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskRetrieval createNew() {
+        return new TaskRetrieval();
+    }
+
+    @Override
+    public TaskRetrieval loadFromData(NBTTagCompound json) {
+        TaskRetrieval task = new TaskRetrieval();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskScoreboard.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskScoreboard.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskScoreboard;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskScoreboard implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskScoreboard INSTANCE = new FactoryTaskScoreboard();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":scoreboard");
-	}
+public class FactoryTaskScoreboard implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskScoreboard INSTANCE = new FactoryTaskScoreboard();
 
-	@Override
-	public TaskScoreboard createNew()
-	{
-		return new TaskScoreboard();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":scoreboard");
+    }
 
-	@Override
-	public TaskScoreboard loadFromData(NBTTagCompound json)
-	{
-		TaskScoreboard task = new TaskScoreboard();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskScoreboard createNew() {
+        return new TaskScoreboard();
+    }
+
+    @Override
+    public TaskScoreboard loadFromData(NBTTagCompound json) {
+        TaskScoreboard task = new TaskScoreboard();
+        task.readFromNBT(json);
+        return task;
+    }
 }

--- a/src/main/java/bq_standard/tasks/factory/FactoryTaskXP.java
+++ b/src/main/java/bq_standard/tasks/factory/FactoryTaskXP.java
@@ -7,28 +7,23 @@ import bq_standard.tasks.TaskXP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
-public class FactoryTaskXP implements IFactoryData<ITask, NBTTagCompound>
-{
-	public static final FactoryTaskXP INSTANCE = new FactoryTaskXP();
-	
-	@Override
-	public ResourceLocation getRegistryName()
-	{
-		return new ResourceLocation(BQ_Standard.MODID + ":xp");
-	}
+public class FactoryTaskXP implements IFactoryData<ITask, NBTTagCompound> {
+    public static final FactoryTaskXP INSTANCE = new FactoryTaskXP();
 
-	@Override
-	public TaskXP createNew()
-	{
-		return new TaskXP();
-	}
+    @Override
+    public ResourceLocation getRegistryName() {
+        return new ResourceLocation(BQ_Standard.MODID + ":xp");
+    }
 
-	@Override
-	public TaskXP loadFromData(NBTTagCompound json)
-	{
-		TaskXP task = new TaskXP();
-		task.readFromNBT(json);
-		return task;
-	}
-	
+    @Override
+    public TaskXP createNew() {
+        return new TaskXP();
+    }
+
+    @Override
+    public TaskXP loadFromData(NBTTagCompound json) {
+        TaskXP task = new TaskXP();
+        task.readFromNBT(json);
+        return task;
+    }
 }


### PR DESCRIPTION
Adds a new option to crafting tasks that will detect previously crafted items based on the count in the player's statistics. This is off by default because the statistics don't care about NBT or metadata, so only vanilla-ish blocks and items make sense to be used here, anything with data that distinguishes between items/blocks in either nbt or damage values cannot use this for reliable detection.

It only triggers when the user manually presses the detect button for now, I'm not sure which event to hook this into to avoid lag, if any.